### PR TITLE
remove default export to fix ESM modules

### DIFF
--- a/.changeset/wise-radios-bake.md
+++ b/.changeset/wise-radios-bake.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/amplify-api-next-alpha': minor
+---
+
+remove default export to fix ESM modules

--- a/__tests__/ModelField.test.ts
+++ b/__tests__/ModelField.test.ts
@@ -1,5 +1,5 @@
 import { expectTypeTestsToPassAsync } from 'jest-tsd';
-import a from '../src/index';
+import { a } from '../src/index';
 import { ModelField, InternalField, __auth } from '../src/ModelField';
 import {
   ModelRelationalField,

--- a/__tests__/ModelType.test.ts
+++ b/__tests__/ModelType.test.ts
@@ -1,5 +1,5 @@
 import { expectTypeTestsToPassAsync } from 'jest-tsd';
-import a, { defineData, ClientSchema } from '../src/index';
+import { a, defineData, ClientSchema } from '../src/index';
 import {
   PublicProviders,
   PrivateProviders,

--- a/playgrounds/data.ts
+++ b/playgrounds/data.ts
@@ -1,4 +1,4 @@
-import { default as a, ClientSchema, defineData } from '../src/index';
+import { a, ClientSchema, defineData } from '../src/index';
 
 const schema = a.schema({
   Post: a
@@ -16,6 +16,6 @@ const schema = a.schema({
 
 export type Schema = ClientSchema<typeof schema>;
 
-export default defineData({
+export const data = defineData({
   schema,
 });

--- a/playgrounds/playground.ts
+++ b/playgrounds/playground.ts
@@ -1,4 +1,4 @@
-import { default as a, defineData } from '../src/index';
+import { a, defineData } from '../src/index';
 
 import type { ModelSchema } from '../src/ModelSchema';
 import { type ModelType } from '../src/ModelType';

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,8 +19,6 @@ const a = {
   ...fields,
 };
 
-export default a;
-
-export { defineData };
+export { a, defineData };
 
 export type { ClientSchema, ModelSchemaType };


### PR DESCRIPTION
*Description of changes:*
Default export from package was causing unexpected behavior when importing this package into an ESM module. See [link](https://github.com/evanw/esbuild/issues/1719#issuecomment-953470495) for more info.

Replacing `export default a` with named export `{a}`

Consumers will need to `import {a} from '@aws-amplify/amplify-api-next-alpha'` going forward.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
