### PR TITLE
change types files back to lib-esm

### DIFF
--- a/.changeset/spicy-rivers-cross.md
+++ b/.changeset/spicy-rivers-cross.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/amplify-api-next-types-alpha': patch
+---
+
+change package types to output d.ts instead of ts files

--- a/packages/amplify-api-next-types/package.json
+++ b/packages/amplify-api-next-types/package.json
@@ -2,8 +2,8 @@
   "name": "@aws-amplify/amplify-api-next-types-alpha",
   "version": "0.0.2",
   "license": "Apache-2.0",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./lib-esm/index.ts",
+  "types": "./lib-esm/index.d.ts",
   "typesVersions": {
     "<5": {
       "lib-esm/index.d.ts": [
@@ -23,7 +23,7 @@
     "typescript": "^5.1.6"
   },
   "files": [
-    "src/**",
+    "lib-esm/**",
     "package.json"
   ]
 }


### PR DESCRIPTION
Samsara api-extractor requires `d.ts` files. Including them in package instead of `.ts`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
