### PR TITLE
fix typesVersion in types package for backwards-compat with DS

### DIFF
--- a/.changeset/red-eels-hang.md
+++ b/.changeset/red-eels-hang.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/amplify-api-next-types-alpha': patch
+---
+
+fix typesVersion in types package for backwards-compat with DS

--- a/packages/amplify-api-next-types/package.json
+++ b/packages/amplify-api-next-types/package.json
@@ -7,7 +7,7 @@
   "typesVersions": {
     "<5": {
       "lib-esm/index.d.ts": [
-        "index.v3.ts"
+        "lib-esm/index.v3.d.ts"
       ]
     }
   },

--- a/packages/amplify-api-next-types/src/index.v3.ts
+++ b/packages/amplify-api-next-types/src/index.v3.ts
@@ -1,0 +1,2 @@
+export * from './builder';
+export * from './client/index.v3';


### PR DESCRIPTION
*Description of changes:*
* Point `typesVersion` to correct file => fix backwards compatibility for packages using older versions of TS (i.e. DataStore)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
