### PR TITLE
fix types package

### DIFF
--- a/.changeset/five-meals-tickle.md
+++ b/.changeset/five-meals-tickle.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/amplify-api-next-types-alpha': patch
+---
+
+add missing file

--- a/packages/amplify-api-next-types/src/index.v3.ts
+++ b/packages/amplify-api-next-types/src/index.v3.ts
@@ -1,2 +1,3 @@
 export * from './builder';
 export * from './client/index.v3';
+export * from './util';


### PR DESCRIPTION
Omitting `util.ts` file from `packages/amplify-api-next-types/src/index.v3.ts` caused it to be omitted from the package


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
