### PR TITLE
rename defineData; remove from public exports

### DIFF
--- a/.changeset/wicked-trees-shop.md
+++ b/.changeset/wicked-trees-shop.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/amplify-api-next-alpha': minor
+'client-types-example': patch
+---
+
+rename defineData; remove from public exports

--- a/examples/client-types-example/package.json
+++ b/examples/client-types-example/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "private": true,
   "scripts": {
     "test": "exit 0"
   },

--- a/packages/amplify-api-next/README.md
+++ b/packages/amplify-api-next/README.md
@@ -4,9 +4,8 @@ TypeScript-first AWS AppSync Schema Builder
 
 ```ts
 import {
-  default as a,
+  a,
   type ClientSchema,
-  defineData,
 } from '@aws-amplify/amplify-api-next-alpha';
 
 const schema = a.schema({
@@ -23,10 +22,7 @@ const schema = a.schema({
 });
 
 export type Schema = ClientSchema<typeof schema>;
-
-export default defineData({
-  schema,
-});
+export schema
 ```
 
 ## Security

--- a/packages/amplify-api-next/index.ts
+++ b/packages/amplify-api-next/index.ts
@@ -1,12 +1,11 @@
-import * as a from './src'
-import { defineData } from './src/SchemaProcessor';
+import * as a from './src';
 import { ClientSchema } from './src/ClientSchema';
 
-  /**
-   * Defines an authorization rule for your data models and fields. First choose an authorization strategy (`public`, 
-   * `private`, `owner`, `group`, or `custom`), then choose an auth provider (`apiKey`, `iam`, `userPools`, `oidc`, or `function`)
-   * and optionally use `.to(...)` to specify the operations that can be performed against your data models and fields.
-   */
-export { a, defineData };
+/**
+ * Defines an authorization rule for your data models and fields. First choose an authorization strategy (`public`,
+ * `private`, `owner`, `group`, or `custom`), then choose an auth provider (`apiKey`, `iam`, `userPools`, `oidc`, or `function`)
+ * and optionally use `.to(...)` to specify the operations that can be performed against your data models and fields.
+ */
+export { a };
 
 export type { ClientSchema };

--- a/packages/amplify-api-next/src/ModelSchema.ts
+++ b/packages/amplify-api-next/src/ModelSchema.ts
@@ -5,7 +5,7 @@ import type {
   InternalModel,
 } from './ModelType';
 export { __auth } from './ModelField';
-import { defineData } from './SchemaProcessor';
+import { processSchema } from './SchemaProcessor';
 
 /*
  * Notes:
@@ -57,7 +57,7 @@ function _schema<T extends ModelSchemaParamShape>(models: T['models']) {
   const transform = (): DerivedApiDefinition => {
     const internalSchema: InternalSchema = { data } as InternalSchema;
 
-    return defineData({ schema: internalSchema });
+    return processSchema({ schema: internalSchema });
   };
 
   return { data, transform } as ModelSchema<T>;
@@ -67,7 +67,7 @@ function _schema<T extends ModelSchemaParamShape>(models: T['models']) {
  * The API and data model definition for Amplify Data. Pass in `{ <NAME>: a.model(...) }` to create a database table
  * and exposes CRUDL operations via an API.
  * @param models The API and data model definition
- * @returns An API and data model definition to be deployed with Amplify (Gen 2) experience (`defineData(...)`)
+ * @returns An API and data model definition to be deployed with Amplify (Gen 2) experience (`processSchema(...)`)
  * or with the Amplify Data CDK construct (`@aws-amplify/data-construct`)
  */
 export function schema<Models extends ModelSchemaModels>(

--- a/packages/amplify-api-next/src/SchemaProcessor.ts
+++ b/packages/amplify-api-next/src/SchemaProcessor.ts
@@ -264,7 +264,7 @@ const schemaPreprocessor = (schema: InternalSchema): string => {
  * @param arg - { schema }
  * @returns DerivedApiDefinition that conforms to IAmplifyGraphqlDefinition
  */
-export function defineData(arg: {
+export function processSchema(arg: {
   schema: InternalSchema;
 }): DerivedApiDefinition {
   const schema = schemaPreprocessor(arg.schema);


### PR DESCRIPTION
*Description of changes:*
* `defineData` implementation now lives in samsara-cli
* don't export `defineData` from this package
* rename internal method `defineData` -> `processSchema` to avoid confusion

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
