### PR TITLE
fix: Mutation inputs should allow incomplete related objects

### DIFF
--- a/packages/amplify-api-next-types/src/client/index.ts
+++ b/packages/amplify-api-next-types/src/client/index.ts
@@ -275,7 +275,7 @@ type WritableKeys<T> = {
 type MutationInput<
   Fields,
   ModelMeta extends Record<any, any>,
-  Relationships = ModelMeta['relationships'],
+  Relationships extends Record<any, any> = ModelMeta['relationships'],
   WritableFields = Pick<Fields, WritableKeys<Fields>>,
 > = {
   [Prop in keyof WritableFields as WritableFields[Prop] extends (
@@ -284,7 +284,18 @@ type MutationInput<
     ? never
     : Prop]: WritableFields[Prop];
 } & {
-  [RelatedModel in keyof Relationships]: Relationships[RelatedModel];
+  [RelatedModel in keyof Relationships]: Partial<
+    Omit<
+      NonNullable<Relationships[RelatedModel]>,
+      NonNullable<Relationships[RelatedModel]>['identifier']
+    >
+  > &
+    Required<
+      Pick<
+        NonNullable<Relationships[RelatedModel]>,
+        NonNullable<Relationships[RelatedModel]>['identifier']
+      >
+    >;
 };
 
 // #endregion

--- a/packages/amplify-api-next/src/ClientSchema.ts
+++ b/packages/amplify-api-next/src/ClientSchema.ts
@@ -50,7 +50,11 @@ export type ClientSchema<
     FilterFieldTypes<OptionalFieldTypes<FieldsWithRelationships>>,
     FilterFieldTypes<ModelImpliedAuthFields<Schema>>
   >,
-  RelationshipMeta = ExtractRelationalMetadata<FlattenedSchema, ResolvedFields>,
+  RelationshipMeta = ExtractRelationalMetadata<
+    FlattenedSchema,
+    ResolvedFields,
+    IdentifierMeta
+  >,
   Meta = IdentifierMeta & RelationshipMeta,
 > = Prettify<
   ResolvedFields & {
@@ -61,6 +65,7 @@ export type ClientSchema<
 type ExtractRelationalMetadata<
   FlattenedSchema,
   ResolvedFields extends Record<string, unknown>,
+  IdentifierMeta,
 > = UnionToIntersection<
   ExcludeEmpty<
     {
@@ -87,14 +92,20 @@ type ExtractRelationalMetadata<
               ? {
                   relationships: Record<
                     `${Lowercase<ModelName & string>}`,
-                    ResolvedFields[ModelName & string]
+                    ResolvedFields[ModelName & string] &
+                      (ModelName extends keyof IdentifierMeta
+                        ? IdentifierMeta[ModelName]
+                        : undefined)
                   >;
                 }
               : {
                   relationships: Partial<
                     Record<
                       Field,
-                      ResolvedFields[FlattenedSchema[ModelName][Field]['relatedModel']]
+                      ResolvedFields[FlattenedSchema[ModelName][Field]['relatedModel']] &
+                        (ModelName extends keyof IdentifierMeta
+                          ? IdentifierMeta[ModelName]
+                          : undefined)
                     >
                   >;
                 }


### PR DESCRIPTION
*Description of changes:*

Fix for issue where all related object fields are required.

<img width="772" alt="image" src="https://github.com/aws-amplify/amplify-api-next/assets/94858815/b48d0a0c-43d8-4f58-ab57-0aa4f27da644">

We want to keep the related object identifier required, which complicated the implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
