### PR TITLE
remove arrayRequired modifiers from hasMany and manyToMany

### DIFF
--- a/.changeset/shy-tomatoes-poke.md
+++ b/.changeset/shy-tomatoes-poke.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/data-schema': patch
+---
+
+depreacte arrayRequired modifier

--- a/package-lock.json
+++ b/package-lock.json
@@ -12221,7 +12221,7 @@
     },
     "packages/data-schema-types": {
       "name": "@aws-amplify/data-schema-types",
-      "version": "0.6.9",
+      "version": "0.6.10",
       "license": "Apache-2.0",
       "dependencies": {
         "rxjs": "^7.8.1"

--- a/packages/data-schema/src/ModelRelationalField.ts
+++ b/packages/data-schema/src/ModelRelationalField.ts
@@ -63,6 +63,8 @@ type ModelRelationalFieldFunctions<
   >;
   /**
    * When set, it requires the relationship to always return an array value
+   * @deprecated this modifier should not be used and will be removed
+   * in the next minor version of this package.
    */
   arrayRequired(): ModelRelationalField<
     SetTypeSubArg<T, 'arrayRequired', true>,
@@ -122,12 +124,12 @@ export type RelationTypeFunctionOmitMapping<
 > = Type extends ModelRelationshipTypes.belongsTo
   ? 'required' | 'arrayRequired' | 'valueRequired'
   : Type extends ModelRelationshipTypes.hasMany
-  ? 'required'
-  : Type extends ModelRelationshipTypes.hasOne
-  ? 'arrayRequired' | 'valueRequired'
-  : Type extends ModelRelationshipTypes.manyToMany
-  ? 'required'
-  : never;
+    ? 'required'
+    : Type extends ModelRelationshipTypes.hasOne
+      ? 'arrayRequired' | 'valueRequired'
+      : Type extends ModelRelationshipTypes.manyToMany
+        ? 'required'
+        : never;
 
 function _modelRelationalField<
   T extends ModelRelationalFieldParamShape,


### PR DESCRIPTION
Marking `arrayRequired` modifiers as deprecated. Will circle back to remove it in the next minor version update.

![image](https://github.com/aws-amplify/amplify-api-next/assets/29709626/0bcd9802-38ca-4a85-9c5c-fa1746b771d7)


