### PR TITLE
fix custom type extraction and selection set

### DIFF
--- a/.changeset/fifty-kids-pretend.md
+++ b/.changeset/fifty-kids-pretend.md
@@ -1,0 +1,6 @@
+---
+'@aws-amplify/data-schema-types': patch
+'@aws-amplify/data-schema': patch
+---
+
+fix nullable custom type field sel. set

--- a/packages/data-schema-types/src/client/index.ts
+++ b/packages/data-schema-types/src/client/index.ts
@@ -172,10 +172,10 @@ export type ModelPath<
 > = {
   done: Field extends string ? `${Field}.*` : never;
   recur: Field extends string
-    ? UnwrapArray<FlatModel[Field]> extends Record<string, unknown>
+    ? NonNullable<UnwrapArray<FlatModel[Field]>> extends Record<string, unknown>
       ?
           | `${Field}.${ModelPath<
-              UnwrapArray<FlatModel[Field]>,
+              NonNullable<UnwrapArray<FlatModel[Field]>>,
               // this decrements `Depth` by 1 in each recursive call; it's equivalent to the update expr. afterthought in a for loop (e.g. `depth -= 1`)
               RecursionLoop[Depth]
             >}`

--- a/packages/data-schema/__tests__/MappedTypes/ExtractNonModelTypes.test-d.ts
+++ b/packages/data-schema/__tests__/MappedTypes/ExtractNonModelTypes.test-d.ts
@@ -79,6 +79,91 @@ describe('ExtractNonModelTypes Mapped Type', () => {
     type test = Expect<Equal<Resolved, Expected>>;
   });
 
+  test('Schema with multiple implicit Custom Types on one model', () => {
+    const s = a.schema({
+      Post: a.model({
+        title: a.string(),
+        metadata: a.json(),
+        location: a.customType({
+          lat: a.float(),
+          long: a.float(),
+        }),
+        altLocation: a.customType({
+          lat: a.float(),
+          long: a.float(),
+        }),
+      }),
+    });
+
+    type Resolved = ExtractNonModelTypes<typeof s>;
+
+    type Expected = {
+      enums: Record<never, never>;
+      customOperations: Record<never, never>;
+      customTypes: {
+        Location: {
+          lat: number | null;
+          long: number | null;
+        };
+        AltLocation: {
+          lat: number | null;
+          long: number | null;
+        };
+      };
+    };
+
+    type test = Expect<Equal<Resolved, Expected>>;
+  });
+
+  test('Schema with implicit and explicit Custom Types on multiple models', () => {
+    const s = a.schema({
+      Post: a.model({
+        title: a.string().required(),
+        description: a.string(),
+        location: a.ref('Location').required(),
+      }),
+
+      Post2: a.model({
+        title: a.string().required(),
+        description: a.string(),
+        location: a.ref('Location'),
+      }),
+
+      Post3: a.model({
+        title: a.string().required(),
+        description: a.string(),
+        altLocation: a.customType({
+          lat: a.float(),
+          long: a.float(),
+        }),
+      }),
+
+      Location: a.customType({
+        lat: a.float(),
+        long: a.float(),
+      }),
+    });
+
+    type Resolved = ExtractNonModelTypes<typeof s>;
+
+    type Expected = {
+      enums: Record<never, never>;
+      customOperations: Record<never, never>;
+      customTypes: {
+        Location: {
+          lat: number | null;
+          long: number | null;
+        };
+        AltLocation: {
+          lat: number | null;
+          long: number | null;
+        };
+      };
+    };
+
+    type test = Expect<Equal<Resolved, Expected>>;
+  });
+
   test('Schema with explicit enum', () => {
     const s = a.schema({
       Post: a.model({

--- a/packages/data-schema/__tests__/MappedTypes/ResolveFieldProperties.test-d.ts
+++ b/packages/data-schema/__tests__/MappedTypes/ResolveFieldProperties.test-d.ts
@@ -1,5 +1,5 @@
 import type { Prettify, Equal, Expect } from '@aws-amplify/data-schema-types';
-import { a, ClientSchema } from '../../index';
+import { a } from '../../index';
 import { ResolveFieldProperties } from '../../src/MappedTypes/ResolveFieldProperties';
 import type { ExtractNonModelTypes } from '../../src/MappedTypes/ExtractNonModelTypes';
 import { Json } from '../../src/ModelField';
@@ -49,8 +49,6 @@ describe('ResolveFieldProperties Mapped Type', () => {
 
     type Schema = typeof s;
 
-    type CS = ClientSchema<Schema>;
-
     type Resolved = Prettify<
       ResolveFieldProperties<Schema, ExtractNonModelTypes<Schema>>['Post']
     >;
@@ -90,8 +88,6 @@ describe('ResolveFieldProperties Mapped Type', () => {
 
     type Schema = typeof s;
 
-    type CS = ClientSchema<Schema>;
-
     type Resolved = Prettify<
       ResolveFieldProperties<Schema, ExtractNonModelTypes<Schema>>['Post']
     >;
@@ -127,8 +123,6 @@ describe('ResolveFieldProperties Mapped Type', () => {
     });
 
     type Schema = typeof s;
-
-    type CS = ClientSchema<Schema>;
 
     type Resolved = Prettify<
       ResolveFieldProperties<Schema, ExtractNonModelTypes<Schema>>['Post']

--- a/packages/data-schema/src/MappedTypes/ExtractNonModelTypes.ts
+++ b/packages/data-schema/src/MappedTypes/ExtractNonModelTypes.ts
@@ -1,3 +1,4 @@
+import type { UnionToIntersection } from '@aws-amplify/data-schema-types';
 import type { CustomType, CustomTypeParamShape } from '../CustomType';
 import type { EnumType, EnumTypeParamShape } from '../EnumType';
 import type { SchemaTypes, ModelTypes } from './ResolveSchema';
@@ -23,14 +24,17 @@ export type ExtractNonModelTypes<Schema> = ResolveNonModelFields<
 type ExtractImplicitNonModelTypes<
   Schema,
   ResolvedModels = ModelTypes<SchemaTypes<Schema>>,
-  ResolvedModelKeys extends keyof ResolvedModels = keyof ResolvedModels,
-> = {
-  [Field in keyof ResolvedModels[ResolvedModelKeys] as ResolvedModels[ResolvedModelKeys][Field] extends
-    | EnumType<EnumTypeParamShape>
-    | CustomType<CustomTypeParamShape>
-    ? `${Capitalize<Field & string>}`
-    : never]: ResolvedModels[ResolvedModelKeys][Field];
-};
+> = UnionToIntersection<
+  {
+    [Model in keyof ResolvedModels]: {
+      [Field in keyof ResolvedModels[Model] as ResolvedModels[Model][Field] extends
+        | EnumType<EnumTypeParamShape>
+        | CustomType<CustomTypeParamShape>
+        ? `${Capitalize<Field & string>}`
+        : never]: ResolvedModels[Model][Field];
+    };
+  }[keyof ResolvedModels]
+>;
 
 type ResolveNonModelTypes<
   Schema,


### PR DESCRIPTION
This PR addresses 2 Custom Type bugs

1 - Makes the required type changes to support an external contributor PR https://github.com/aws-amplify/amplify-js/pull/12750

When a nullable field references a Custom Type, the Custom Type's properties should be included in the custom selection set path type:

```ts
// resource.ts

Post: a.model({
  title: a.string().required(),
  description: a.string(),
  location: a.ref('Location')
})

// app.ts

await client.models.Post.list({ selectionSet: ['location.lat', 'location.long', 'location.*'] })
```

2 - While working on this change, I discovered a bug where implicit/inline Custom Types were not getting extracted correctly in schemas with more than 1 model. This is now fixed and tests have been added.

Before this PR we would correctly extract an inline custom type from a schema with a single model
```ts
const s = a.schema({
  Post: a.model({
     location: a.customType({
        lat: a.float(),
        long: a.float(),
      })
  })
})

type Schema = ClientSchema<typeof s>

type CustomTypes = Schema[typeof __modelMeta__]['customTypes']
//      ^?
{
 Location: {
    lat: number | null;
    long: number | null;
  }
}
```

However, if we had >= 2 models in the schema, the extraction would fail:
```ts
const s = a.schema({
  Post: a.model({
     location: a.customType({
        lat: a.float(),
        long: a.float(),
      })
  }),
  Comments: a.model({
    someField: a.string()
  })
})

type Schema = ClientSchema<typeof s>

type CustomTypes = Schema[typeof __modelMeta__]['customTypes']
//      ^?
{}
```

Related implementation change: https://github.com/aws-amplify/amplify-api-next/pull/85/files#diff-7af1736d802bf0885def33064f2427e31a626591c977a3f3136a307357a69469R27-R37

Relevant tests validating expected behavior:
* https://github.com/aws-amplify/amplify-api-next/pull/85/files#diff-28eded760e1b856fb5cb5211ad170c91d148ae0e8cb834a12ea5f1883cf4d496R118-R165
* https://github.com/aws-amplify/amplify-api-next/pull/85/files#diff-22e55aba2e0b5c58c5f7efb77760809432757ef7bd0c5cfd5abc91997785a68dR429-R513