### PR TITLE
feat: Add daily cron to unit test specific typescript versions

### DIFF
--- a/.github/workflows/callable-ts-version-unit-test.yml
+++ b/.github/workflows/callable-ts-version-unit-test.yml
@@ -1,0 +1,27 @@
+name: Unit Tests
+
+on:
+  workflow_call:
+    inputs:
+      tsVersion:
+        required: true
+        type: string
+jobs:
+  unit_test:
+    name: Lint & Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        with:
+          path: amplify-api-next
+      - name: Install specific typescript version
+        env:
+          VERSION: ${{ inputs.tsVersion }}
+        working-directory: ./amplify-api-next
+        run: npm i typescript@$VERSION
+      - name: Setup node and build the repository
+        uses: ./amplify-api-next/.github/actions/node-and-build
+      - name: Run tests
+        working-directory: ./amplify-api-next
+        run: npm run lint && npm run test

--- a/.github/workflows/on-schedule-ts-canary.yml
+++ b/.github/workflows/on-schedule-ts-canary.yml
@@ -1,0 +1,22 @@
+on:
+  # Tests scheduled at 6pm(UTC) / 11am(PDT) everyday
+  # default supported timezone is UTC
+  schedule:
+    - cron: '0 18 * * *'
+
+jobs:
+  rc-canary:
+    secrets: inherit
+    uses: ./.github/workflows/callable-ts-version-unit-test.yml
+    with:
+      tsVersion: 'rc'
+  next-canary:
+    secrets: inherit
+    uses: ./.github/workflows/callable-ts-version-unit-test.yml
+    with:
+      tsVersion: 'next'
+  latest-canary:
+    secrets: inherit
+    uses: ./.github/workflows/callable-ts-version-unit-test.yml
+    with:
+      tsVersion: 'latest'

--- a/package-lock.json
+++ b/package-lock.json
@@ -12191,7 +12191,7 @@
     },
     "packages/data-schema": {
       "name": "@aws-amplify/data-schema",
-      "version": "0.12.13",
+      "version": "0.12.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*"
@@ -12210,7 +12210,7 @@
     },
     "packages/data-schema-types": {
       "name": "@aws-amplify/data-schema-types",
-      "version": "0.6.11",
+      "version": "0.6.12",
       "license": "Apache-2.0",
       "dependencies": {
         "rxjs": "^7.8.1"


### PR DESCRIPTION
*Issue #, if available:*
- Canary script described in https://github.com/aws-amplify/amplify-api-next/issues/79

*Description of changes:*
This adds a workflow that runs daily that executes the unit tests against `typescript`@`rc`/`next`/`latest`. All of which fail at the moment.

I have tested this script [against `5.2.2`](https://github.com/stocaaro/amplify-api-next/actions/runs/7632551486) to confirm that it does pass when it should.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
