### PR TITLE
chore: add client.enums property type integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -101,9 +101,9 @@
       "dev": true
     },
     "node_modules/@aws-amplify/analytics": {
-      "version": "7.0.16",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.16.tgz",
-      "integrity": "sha512-K/1h/IxUBcDVjB48XTAu+rYSoQkgtYkcHwALu8hKW111Uw/mzApxiXlF/vvN71EnD1SeFmTPHoSmmjjVfFS4lA==",
+      "version": "7.0.17",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/analytics/-/analytics-7.0.17.tgz",
+      "integrity": "sha512-GNT/jyztx61FQ1Xr7V18llDRpBSFqTHk8WcshCDFm9ZQAXC1TvnpxavoKIolBeXTpPJ0L3HJ7X3TxvWnUYkYIQ==",
       "dependencies": {
         "@aws-sdk/client-firehose": "3.398.0",
         "@aws-sdk/client-kinesis": "3.398.0",
@@ -116,23 +116,23 @@
       }
     },
     "node_modules/@aws-amplify/api": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.16.tgz",
-      "integrity": "sha512-XKutBlvPZRB6AN0JZA5S1sQbS34xKYMXQiccvC/xDUPaJyNG/I6vw6zlGO0GH6TjzGdLJBlDWann5/1W+7FUvA==",
+      "version": "6.0.17",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-6.0.17.tgz",
+      "integrity": "sha512-76PvRRhbkzenr2X5a9DNupFKu6kBmbZ0KI0yFqaqXdAMQjvtm8GrqY/1yFnMcSqHH8mlUmexYP8lKrOX5sZqmQ==",
       "dependencies": {
-        "@aws-amplify/api-graphql": "4.0.16",
-        "@aws-amplify/api-rest": "4.0.16",
+        "@aws-amplify/api-graphql": "4.0.17",
+        "@aws-amplify/api-rest": "4.0.17",
         "tslib": "^2.5.0"
       }
     },
     "node_modules/@aws-amplify/api-graphql": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.0.16.tgz",
-      "integrity": "sha512-Ttx3bU6xuoVhDWqQt1x5zANo5/VaurFG3BiEyqDF2Nt0z8D4vSefQ7HVQ29S9Y9Q5X7Wcn2cSAHACUKgMgpFrw==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-graphql/-/api-graphql-4.0.17.tgz",
+      "integrity": "sha512-/3g5GJ1vvDoux1SPHzrDWghoJR101EKhUnjgt5+uS7+zcLJlT6s5mOz0unhMD5Phvtjhcc33sukoC7A7y3xAYA==",
       "dependencies": {
-        "@aws-amplify/api-rest": "4.0.16",
-        "@aws-amplify/core": "6.0.16",
-        "@aws-amplify/data-schema-types": "^0.7.1",
+        "@aws-amplify/api-rest": "4.0.17",
+        "@aws-amplify/core": "6.0.17",
+        "@aws-amplify/data-schema-types": "^0.7.2",
         "@aws-sdk/types": "3.387.0",
         "graphql": "15.8.0",
         "rxjs": "^7.8.1",
@@ -141,9 +141,9 @@
       }
     },
     "node_modules/@aws-amplify/api-rest": {
-      "version": "4.0.16",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.16.tgz",
-      "integrity": "sha512-S7e4ySWhiZziEoF5QdBqvGMjTgQjShyEEkCHdRQUITsz6C8gwj7xrRci5mh0Szy4LKD7gyTqIcVyKMViy5GEVw==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/api-rest/-/api-rest-4.0.17.tgz",
+      "integrity": "sha512-cpl9sIn7pJscnHmQa5LYd2gdItuWu4pJ/zjsRXXhp1/Or2iX0fxUs1r3oPEq+eDjSmDmO5c89bQbNO4spqgs0g==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -152,9 +152,9 @@
       }
     },
     "node_modules/@aws-amplify/auth": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.0.16.tgz",
-      "integrity": "sha512-s5Yi+4T6+fyLgcqQnAkBdsGKWDAQ4t5OYcSfC3EyAHeVeR6te5nTRuKGuS3cwHJmJ15SlAgL0Zkzy0m9tWjHfw==",
+      "version": "6.0.17",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/auth/-/auth-6.0.17.tgz",
+      "integrity": "sha512-VnksOAjBRm/TskkSjkLq7rzGJItpT2oDlUIddzGlGeILAumpTpv2PX5Jx3tfqghsQpn9kXE1AP8YgpOhuVDIDw==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -163,9 +163,9 @@
       }
     },
     "node_modules/@aws-amplify/core": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.0.16.tgz",
-      "integrity": "sha512-Y2Nq1961Qg3U67H3IsBvohknw53gsvrghFPln2JZhMtsCVyqmnVC2/P/ah4+F4AkQQTpo6ny2lKqtN0PrYFP5w==",
+      "version": "6.0.17",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/core/-/core-6.0.17.tgz",
+      "integrity": "sha512-ruQuDN6owk6z3R6baQf/JV391DkgJr6IP0n/BdiiQR+jeLLoHtQbWrMUfVR4wwyIYSPph6fH2PMvggutAkD1fw==",
       "dependencies": {
         "@aws-crypto/sha256-js": "5.2.0",
         "@aws-sdk/types": "3.398.0",
@@ -198,11 +198,11 @@
       "link": true
     },
     "node_modules/@aws-amplify/datastore": {
-      "version": "5.0.16",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.16.tgz",
-      "integrity": "sha512-jIo5VDij3uPHqZ9guOnU2taLQydBbFbwUgm/GaW47tAUeFCPgImlxOBvXk+Nae09EF37IENUsJ9Ng60UmmLVpA==",
+      "version": "5.0.17",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/datastore/-/datastore-5.0.17.tgz",
+      "integrity": "sha512-bzV24IueXIBAy4+UAi90bZeSPHcVKmUWr05Y5MCB/GzX0TibppkE0FdE3zgMXk0pRcxzmxG+Bg6dUh5Nkco4Ow==",
       "dependencies": {
-        "@aws-amplify/api": "6.0.16",
+        "@aws-amplify/api": "6.0.17",
         "buffer": "4.9.2",
         "idb": "5.0.6",
         "immer": "9.0.6",
@@ -214,9 +214,9 @@
       }
     },
     "node_modules/@aws-amplify/notifications": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.16.tgz",
-      "integrity": "sha512-SrrOSH6khaeo7WuDMmHKiEq+H9D3ch6cnX2EHMoD7eCGgjLu3zsCdRwYDVUlnNTexa0t4Fb58hiSUC8WyDP2HA==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/notifications/-/notifications-2.0.17.tgz",
+      "integrity": "sha512-xi+cm/b3KQInD/U4f3xmxcbzqOm1kbbkF6GPG1Bt62MEnEjVQqcXOMS0zfUpa5OKp8ocaDSlZR+RQzVy6moFSQ==",
       "dependencies": {
         "lodash": "^4.17.21",
         "tslib": "^2.5.0"
@@ -226,9 +226,9 @@
       }
     },
     "node_modules/@aws-amplify/storage": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.0.16.tgz",
-      "integrity": "sha512-Ck1aHP4tD3WXAwnFQpbcadOnW2tfnOoeJWhrzDQl1UZ27zbKkEsKKF0qPa1hfg7aRLQHAsu0bR2T166ZMcMoqw==",
+      "version": "6.0.17",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/storage/-/storage-6.0.17.tgz",
+      "integrity": "sha512-WUXKQ1q5BrxJtR9of7ffqQmZT/v2YaIvl7kJcQKMiTJ6Sk/lKb2lNncpaIHu4nl89j7tgCaqJiGVuB76HqybSg==",
       "dependencies": {
         "@aws-sdk/types": "3.398.0",
         "@smithy/md5-js": "2.0.7",
@@ -4886,17 +4886,17 @@
       }
     },
     "node_modules/aws-amplify": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.0.16.tgz",
-      "integrity": "sha512-6pJti0sju6+GNZ/f68XK0DPVdpXMYCnfaVZgGOwqkp81f3I0kkleNFqXltFCLB+en7GGsX7E7HGmtnJb1RziOQ==",
+      "version": "6.0.17",
+      "resolved": "https://registry.npmjs.org/aws-amplify/-/aws-amplify-6.0.17.tgz",
+      "integrity": "sha512-57tFeE89XsVIe+2zusu4SDXHMGkUbc5vs4hHahDimkMYaiQJFSJWZ7yhMVVmfL9sCEG8BQXUxp4q46qZkANOJw==",
       "dependencies": {
-        "@aws-amplify/analytics": "7.0.16",
-        "@aws-amplify/api": "6.0.16",
-        "@aws-amplify/auth": "6.0.16",
-        "@aws-amplify/core": "6.0.16",
-        "@aws-amplify/datastore": "5.0.16",
-        "@aws-amplify/notifications": "2.0.16",
-        "@aws-amplify/storage": "6.0.16",
+        "@aws-amplify/analytics": "7.0.17",
+        "@aws-amplify/api": "6.0.17",
+        "@aws-amplify/auth": "6.0.17",
+        "@aws-amplify/core": "6.0.17",
+        "@aws-amplify/datastore": "5.0.17",
+        "@aws-amplify/notifications": "2.0.17",
+        "@aws-amplify/storage": "6.0.17",
         "tslib": "^2.5.0"
       }
     },
@@ -12242,7 +12242,7 @@
     },
     "packages/data-schema": {
       "name": "@aws-amplify/data-schema",
-      "version": "0.13.3",
+      "version": "0.13.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*"
@@ -12278,7 +12278,7 @@
         "@aws-amplify/data-schema-types": "*",
         "@tsd/typescript": "^5.1.6",
         "@types/jest": "29.5.4",
-        "aws-amplify": "^6.0.16",
+        "aws-amplify": "^6.0.17",
         "jest": "^29.7.0",
         "jest-tsd": "^0.2.2",
         "ts-jest": "^29.1.1"

--- a/packages/integration-tests/__tests__/enums-and-custom-types.test-d.ts
+++ b/packages/integration-tests/__tests__/enums-and-custom-types.test-d.ts
@@ -55,6 +55,18 @@ describe('Enum', () => {
 
       type test = Expect<Equal<ResolvedUpdateParams, ExpectedUpdateParams>>;
     });
+
+    test('The `.enums` property should contain expect enum type and values getter function', () => {
+      type EnumsProp = typeof client.enums;
+
+      type ExpectedEnumsPropShape = {
+        PostStatus: {
+          values(): ('draft' | 'pending' | 'published')[];
+        };
+      };
+
+      type test = Expect<Equal<EnumsProp, ExpectedEnumsPropShape>>;
+    });
   });
 
   describe('Explicit Enum Type; multiple models', () => {
@@ -153,6 +165,18 @@ describe('Enum', () => {
       type test2 = Expect<
         Equal<ResolvedUpdateCommentParams, ExpectedUpdateCommentParams>
       >;
+    });
+
+    test('The `.enums` property should contain expect enum type and values getter function', () => {
+      type EnumsProp = typeof client.enums;
+
+      type ExpectedEnumsPropShape = {
+        Status: {
+          values(): ('draft' | 'pending' | 'published')[];
+        };
+      };
+
+      type test = Expect<Equal<EnumsProp, ExpectedEnumsPropShape>>;
     });
   });
 });

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -10,7 +10,7 @@
   "devDependencies": {
     "@aws-amplify/data-schema": "*",
     "@aws-amplify/data-schema-types": "*",
-    "aws-amplify": "^6.0.16",
+    "aws-amplify": "^6.0.17",
     "@tsd/typescript": "^5.1.6",
     "@types/jest": "29.5.4",
     "jest": "^29.7.0",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Added `client.enums` type integration tests with upgrading `aws-amplify` library to v6.0.17 which contains the corresponding implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
