### PR TITLE
fix: Json field type mismatch in uni tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "rimraf": "^5.0.5",
         "ts-jest": "^29.1.1",
         "turbo": "^1.10.14",
-        "typescript": "5.2.2"
+        "typescript": "^5.1.6"
       }
     },
     "examples/client-types-example": {
@@ -11835,9 +11835,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -12243,7 +12243,7 @@
     },
     "packages/data-schema": {
       "name": "@aws-amplify/data-schema",
-      "version": "0.13.8",
+      "version": "0.13.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "rimraf": "^5.0.5",
     "ts-jest": "^29.1.1",
     "turbo": "^1.10.14",
-    "typescript": "5.2.2"
+    "typescript": "^5.1.6"
   }
 }

--- a/packages/data-schema/__tests__/MappedTypes/ModelMetadata.test-d.ts
+++ b/packages/data-schema/__tests__/MappedTypes/ModelMetadata.test-d.ts
@@ -437,7 +437,9 @@ describe('RelationalMetadata', () => {
             readonly createdAt?: string;
             readonly updatedAt?: string;
             title?: string | null | undefined;
-            metadata?: Json | null | undefined;
+            // metadata: a.json().required() => Required<Json> removes `null` from the union
+            // see packages/data-schema/src/ModelField.ts
+            metadata?: Exclude<Json, null> | undefined;
             postTags?: ResolvedFields['Post']['postTags'];
           };
           tag?: {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Apparently ts 5.2.2 couldn't detect this for some reason. With 5.2.2, when I manually inserting the following statement in the test suite, ts could correctly infer the types and started complaining against `Equal<Resolved, Expected>`

```ts
type Post = Resolved['PostTag']['relationalInputFields']['post']
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
