### PR TITLE
fix: add builder.v3 types without plugin-types dep

### DIFF
--- a/.changeset/eight-pillows-learn.md
+++ b/.changeset/eight-pillows-learn.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/data-schema-types": patch
+---
+
+add builder.v3 types without plugin-types dep

--- a/packages/data-schema-types/src/builder/index.v3.ts
+++ b/packages/data-schema-types/src/builder/index.v3.ts
@@ -1,0 +1,1 @@
+export * from './types.v3';

--- a/packages/data-schema-types/src/builder/types.v3.ts
+++ b/packages/data-schema-types/src/builder/types.v3.ts
@@ -1,0 +1,52 @@
+/**
+ * references IAmplifyGraphqlDefinition from:
+ * https://github.com/aws-amplify/amplify-category-api/blob/4c0ea253a0bae51f775383929ba4748593185bc1/packages/amplify-graphql-api-construct/src/types.ts#L491-L503
+ *
+ * function slots is any'd for now. Will add actual type when we add support for this feature
+ */
+
+export interface DerivedApiDefinition {
+  /**
+   * Return the schema definition as a graphql string, with amplify directives allowed.
+   * @returns the rendered schema.
+   */
+  readonly schema: string;
+
+  /**
+   * Retrieve any function slots defined explicitly in the Api definition.
+   * @returns generated function slots
+   */
+  readonly functionSlots: any[];
+  readonly jsFunctions: JsResolver[];
+  readonly lambdaFunctions: LambdaFunctionDefinition;
+  readonly functionSchemaAccess: FunctionSchemaAccess[];
+}
+
+export type DerivedModelSchema = {
+  data: {
+    types: object;
+  };
+  transform: () => DerivedApiDefinition;
+};
+
+export type JsResolverEntry =
+  | string
+  | { relativePath: string; importLine: string };
+
+export type JsResolver = {
+  typeName: 'Mutation' | 'Query' | 'Subscription';
+  fieldName: string;
+  handlers: {
+    dataSource: string;
+    entry: JsResolverEntry;
+  }[];
+};
+
+export type LambdaFunctionDefinition = Record<string, DefineFunction>;
+
+export type FunctionSchemaAccess = {
+  resourceProvider: DefineFunction;
+  actions: ('query' | 'mutate' | 'listen')[];
+};
+
+export type DefineFunction = any;

--- a/packages/data-schema-types/src/index.v3.ts
+++ b/packages/data-schema-types/src/index.v3.ts
@@ -1,3 +1,3 @@
-export * from './builder';
+export * from './builder/types.v3';
 export * from './client/index.v3';
 export * from './util';


### PR DESCRIPTION
Resolve this `tsc` compliance check in the JS pipeline: https://github.com/aws-amplify/amplify-js/actions/runs/8377597738/job/22940313482?pr=13154#step:4:7

* Adds a `.v3` version of the builder types exported from the types package. Same as what we have for the client types.

A better long-term solution would be subpathing `/client`, `/builder`. And only importing from `/client` in JS. However, I was running into some issues with `typesVersions` for the subpath, so deferring that for now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
