### PR TITLE
fix: explicit dep on @aws-amplify/plugin-types

### DIFF
--- a/.changeset/nervous-islands-pay.md
+++ b/.changeset/nervous-islands-pay.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/data-schema-types": patch
+---
+
+types - explicit dep on plugin-types

--- a/package-lock.json
+++ b/package-lock.json
@@ -816,10 +816,9 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-amplify/plugin-types": {
-      "version": "0.9.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-0.9.0-beta.0.tgz",
-      "integrity": "sha512-LsdE5JW9XbYokFgukyZrVHVvh18xi9Q8vtQUcC8EtK4JiMSH5SF2L1M5GI9jFC0qJnJhYXlUowuodo3uxmGyJw==",
-      "dev": true,
+      "version": "0.9.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/plugin-types/-/plugin-types-0.9.0-beta.1.tgz",
+      "integrity": "sha512-5eJ2SYoXbq4ZSvBjCgStXSejNOKuBkxYVXqOXZP4xP5C9iIpUYG36s9xP+IdhWDm9K/yxklp8OUMr8YGc0g7tw==",
       "peerDependencies": {
         "aws-cdk-lib": "^2.127.0",
         "constructs": "^10.0.0"
@@ -861,21 +860,18 @@
       "version": "2.2.202",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.202.tgz",
       "integrity": "sha512-JqlF0D4+EVugnG5dAsNZMqhu3HW7ehOXm5SDMxMbXNDMdsF0pxtQKNHRl52z1U9igsHmaFpUgSGjbhAJ+0JONg==",
-      "dev": true,
       "peer": true
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-kubectl-v20/-/asset-kubectl-v20-2.1.2.tgz",
       "integrity": "sha512-3M2tELJOxQv0apCIiuKQ4pAbncz9GuLwnKFqxifWfe77wuMxyTRPmxssYHs42ePqzap1LT6GDcPygGs+hHstLg==",
-      "dev": true,
       "peer": true
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.0.1.tgz",
       "integrity": "sha512-DDt4SLdLOwWCjGtltH4VCST7hpOI5DzieuhGZsBpZ+AgJdSI2GCjklCXm0GCTwJG/SolkL5dtQXyUKgg9luBDg==",
-      "dev": true,
       "peer": true
     },
     "node_modules/@aws-crypto/crc32": {
@@ -6726,7 +6722,6 @@
         "yaml",
         "mime-types"
       ],
-      "dev": true,
       "peer": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.202",
@@ -6753,14 +6748,12 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
       "version": "8.12.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6777,7 +6770,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6787,7 +6779,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6803,7 +6794,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/astral-regex": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6813,14 +6803,12 @@
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6831,7 +6819,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
       "version": "1.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "peer": true,
@@ -6841,7 +6828,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6854,35 +6840,30 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6897,14 +6878,12 @@
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
       "version": "5.3.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6914,7 +6893,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6924,14 +6902,12 @@
     },
     "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6944,7 +6920,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
       "version": "1.4.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6954,14 +6929,12 @@
     },
     "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
       "version": "4.4.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/lru-cache": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -6974,7 +6947,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6984,7 +6956,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/mime-types": {
       "version": "2.1.35",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -6997,7 +6968,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -7010,7 +6980,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
       "version": "2.3.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -7020,7 +6989,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/require-from-string": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -7030,7 +6998,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
       "version": "7.6.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -7046,7 +7013,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -7064,7 +7030,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -7079,7 +7044,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -7092,7 +7056,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
       "version": "6.8.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -7109,7 +7072,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peer": true,
@@ -7119,7 +7081,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/uri-js": {
       "version": "4.4.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "peer": true,
@@ -7129,14 +7090,12 @@
     },
     "node_modules/aws-cdk-lib/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "peer": true,
@@ -7928,7 +7887,6 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.3.0.tgz",
       "integrity": "sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==",
-      "dev": true,
       "peer": true,
       "engines": {
         "node": ">= 16.14.0"
@@ -15404,10 +15362,10 @@
       "version": "0.7.11",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-amplify/plugin-types": "^0.9.0-beta.1",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {
-        "@aws-amplify/plugin-types": "^0.9.0-beta.0",
         "typescript": "^5.1.6"
       }
     },

--- a/packages/data-schema-types/package.json
+++ b/packages/data-schema-types/package.json
@@ -21,8 +21,7 @@
     "lint": "eslint ."
   },
   "devDependencies": {
-    "typescript": "^5.1.6",
-    "@aws-amplify/plugin-types": "^0.9.0-beta.0"
+    "typescript": "^5.1.6"
   },
   "files": [
     "src",
@@ -30,6 +29,7 @@
     "package.json"
   ],
   "dependencies": {
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "@aws-amplify/plugin-types": "^0.9.0-beta.1"
   }
 }


### PR DESCRIPTION
JS customers using the gen2 GraphQL experience _without_ gen2 amplify-backend installed in their project and who also have `skipLibCheck: false` in their tsconfig may encounter compilation issues due to the `data-schema-types` package importing from `@aws-amplify/plugin-types`. 

This change adds plugin-types (a pure types package managed by the gen2 team) as an explicit dependency.

We can revert this change and remove the dep if we either: 
  A. Fold the client types into `data-schema`, removing JS dependency on `data-schema-types`
_OR_
  B. If we implement subpath imports for the types package, e.g. `import {someType} from '@aws-amplify/data-schema-types/client` since the client types do not import from `@aws-amplify/plugin-types`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
