### PR TITLE
chore: print type errors (if any) while running benches

### DIFF
--- a/packages/benches/p50/operations/p50-prod-CRUDL.bench.ts
+++ b/packages/benches/p50/operations/p50-prod-CRUDL.bench.ts
@@ -507,6 +507,7 @@ bench('prod p50 CRUDL', async () => {
     },
   });
 
+  // @ts-expect-error Type instantiation is excessively deep and possibly infinite is expected for this schema
   const client = generateClient<Schema>();
 
   const result = await client.models.Todo.create({

--- a/packages/benches/p50/operations/p50-prod-selection-set.bench.ts
+++ b/packages/benches/p50/operations/p50-prod-selection-set.bench.ts
@@ -509,6 +509,7 @@ bench('prod p50 CRUDL', async () => {
     },
   });
 
+  // @ts-expect-error Type instantiation is excessively deep and possibly infinite is expected for this schema
   const client = generateClient<Schema>();
 
   const result = await client.models.Todo.create({

--- a/packages/benches/p99/over-limit/operations/p99-tall-simple-CRUDL.bench.ts
+++ b/packages/benches/p99/over-limit/operations/p99-tall-simple-CRUDL.bench.ts
@@ -4581,6 +4581,7 @@ bench('1522 simple models with 1 field each CRUDL', async () => {
     })
     .authorization([a.allow.public()]);
 
+  // @ts-expect-error Type instantiation is excessively deep and possibly infinite is expected for this schema
   type _ = ClientSchema<typeof schema>;
 
   // TODO:

--- a/packages/benches/p99/over-limit/operations/p99-wide-large-CRUDL.bench.ts
+++ b/packages/benches/p99/over-limit/operations/p99-wide-large-CRUDL.bench.ts
@@ -2521,7 +2521,7 @@ bench(
           field214: a.string(),
           field215: a.string(),
         }),
-        Model1: a.model({
+        Model36: a.model({
           field1: a.string(),
           field2: a.string(),
           field3: a.string(),
@@ -10119,7 +10119,6 @@ bench(
       })
       .authorization([a.allow.public()]);
 
-    //@ts-expect-error - working schema:
     type _ = ClientSchema<typeof schema>;
 
     // TODO:

--- a/packages/benches/p99/over-limit/p99-tall-simple.bench.ts
+++ b/packages/benches/p99/over-limit/p99-tall-simple.bench.ts
@@ -9148,5 +9148,6 @@ bench('1522 simple models with 1 field each w/ client types', () => {
     })
     .authorization([a.allow.public()]);
 
+  // @ts-expect-error Type instantiation is excessively deep and possibly infinite is expected for this schema
   type _ = ClientSchema<typeof s>;
 }).types([9618855, 'instantiations']);

--- a/packages/benches/scripts/run-benches.sh
+++ b/packages/benches/scripts/run-benches.sh
@@ -9,7 +9,7 @@ if [[ -d "$1" ]]; then
     echo Benchmarking: "$file"
     echo ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    npm run tsx "$file"
+    npx tsc "$file" --noEmit --skipLibCheck --lib ES2022 --strict true && npm run tsx "$file"
   done
 else
   echo "The argument provided is not a directory."


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This is an quicker alternative than implement a feature in the 3rd-party attest package which delivers what we need for now.

To run `tsc` on the bench test file to check type errors before running the benchmark, and print the type error.

* Added `@ts-expect-error` for spots that expect type errors so `tsc` won't print expected errors

<img width="946" alt="image" src="https://github.com/aws-amplify/amplify-api-next/assets/10602282/6e7af14b-9511-436a-917e-704ac0437c8b">



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
