### PR TITLE
chore: use new modelgen with ref support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -344,9 +344,9 @@
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-amplify/appsync-modelgen-plugin": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.9.0.tgz",
-      "integrity": "sha512-RKrJTnE4P/WVs27mLodBngVHT8W+Jxnyp1x7Dw4vALZS+ihBYzUmLaIfcZbkrVa8jkgjeJaG2ZIWSFlXcqb2iw==",
+      "version": "2.11.0-gen2-release-0411.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/appsync-modelgen-plugin/-/appsync-modelgen-plugin-2.11.0-gen2-release-0411.0.tgz",
+      "integrity": "sha512-ge16Gb+trcY36sowqL4Y9VK7wdDj5QfkLG4cbAGIBK8PBv4dd5Mr5CCEtSjJ73e9icCUTpYc5X/5HS9Ak0rBQQ==",
       "dependencies": {
         "@graphql-codegen/plugin-helpers": "^1.18.8",
         "@graphql-codegen/visitor-plugin-common": "^1.22.0",
@@ -497,6 +497,11 @@
         "@aws-amplify/core": "^6.0.0"
       }
     },
+    "node_modules/@aws-amplify/graphql-directives": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-directives/-/graphql-directives-1.0.1.tgz",
+      "integrity": "sha512-oUUQJU1syzUfU4P4z+fLDLklU9wmEZokgQOAKHBN5Szest/mDkjZEbG9VVBiMaQbq1Rw0jkRJmVU9WA1vxjT2A=="
+    },
     "node_modules/@aws-amplify/graphql-docs-generator": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-docs-generator/-/graphql-docs-generator-4.2.1.tgz",
@@ -593,13 +598,14 @@
       }
     },
     "node_modules/@aws-amplify/graphql-generator": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.2.4.tgz",
-      "integrity": "sha512-Wuez+sbba1wJXvBXYAaimHQiC4Kziuq4TDGrEAItxrvcvEr0jRM1skmQjI/DXAEPDMKmWDPjoMusGtPpyPYG9A==",
+      "version": "0.4.0-gen2-release-0411.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-generator/-/graphql-generator-0.4.0-gen2-release-0411.0.tgz",
+      "integrity": "sha512-7WRXr2TYBFh/YRjzfoXb3ZUnCAvfg48p8v7OMHd+7TDMDC5YG+BoUxRirACg5G2rmnr7R3yv8OcNtF5EmkbZdg==",
       "dependencies": {
-        "@aws-amplify/appsync-modelgen-plugin": "2.9.0",
+        "@aws-amplify/appsync-modelgen-plugin": "2.11.0-gen2-release-0411.0",
+        "@aws-amplify/graphql-directives": "^1.0.1",
         "@aws-amplify/graphql-docs-generator": "4.2.1",
-        "@aws-amplify/graphql-types-generator": "3.4.6",
+        "@aws-amplify/graphql-types-generator": "3.6.0-gen2-release-0411.0",
         "@graphql-codegen/core": "^2.6.6",
         "@graphql-tools/apollo-engine-loader": "^8.0.0",
         "graphql": "^15.5.0",
@@ -618,9 +624,9 @@
       }
     },
     "node_modules/@aws-amplify/graphql-types-generator": {
-      "version": "3.4.6",
-      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.4.6.tgz",
-      "integrity": "sha512-ZyVU5EV7uF/h7JFg0vKlF/DkYDKJYW+U+tB3QMoRjqq4rWWt1DENq22FYARfNgV3Cl8FPHxaxozzTCw2bS7JyA==",
+      "version": "3.6.0-gen2-release-0411.0",
+      "resolved": "https://registry.npmjs.org/@aws-amplify/graphql-types-generator/-/graphql-types-generator-3.6.0-gen2-release-0411.0.tgz",
+      "integrity": "sha512-s3ivNmm6wTQ98L3UHCsiIud0qOEGF2j6WGM+kbTLh4Ej7DxGitl4oKfExTeRvfGiW/WmfWlRF5u0yDcvpsvKJA==",
       "dependencies": {
         "@babel/generator": "7.0.0-beta.4",
         "@babel/types": "7.0.0-beta.4",
@@ -2216,9 +2222,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.1.tgz",
-      "integrity": "sha512-1yJa9dX9g//V6fDebXoEfEsxkZHk3Hcbm+zLhyu6qVgYFLvmTALTeV+jNU9e5RnYtioBrGEOdoI2joMSNQ/+aA==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.24.4.tgz",
+      "integrity": "sha512-lG75yeuUSVu0pIcbhiYMXBXANHrpUPaOfu7ryAzskCgKUHuAxRQI5ssrtmF0X9UXldPlvT0XM/A4F44OXRt6iQ==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -2698,9 +2704,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.24.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.1.tgz",
-      "integrity": "sha512-h71T2QQvDgM2SmT29UYU6ozjMlAt7s7CSs5Hvy8f8cf/GM/Z4a2zMfN+fjVGaieeCrXR3EdQl6C4gQG+OgmbKw==",
+      "version": "7.24.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.24.4.tgz",
+      "integrity": "sha512-nIFUZIpGKDf9O9ttyRXpHFpKC+X3Y5mtshZONuEUYBomAKoM4y029Jr+uB1bHGPhNmK8YXHevDtKDOLmtRrp6g==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.0"
       },
@@ -10043,9 +10049,9 @@
       }
     },
     "node_modules/graphql-transformer-common": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/graphql-transformer-common/-/graphql-transformer-common-4.28.1.tgz",
-      "integrity": "sha512-ui+6DGStFWBu92G6oUXdRJ3Rb8qeT0f+GgCko2xMeDPqy52VUanVAI/2NtuOh+jBwpcrH/sygKQJJOg7orCEag==",
+      "version": "4.30.0",
+      "resolved": "https://registry.npmjs.org/graphql-transformer-common/-/graphql-transformer-common-4.30.0.tgz",
+      "integrity": "sha512-NsY2dmRfejkS80SdzLnmXgZurJXdCKitwhkWYPjGBwH+K3mXRAT+8ZnhqAGg1eEYuWzPswdBozaLs52bn98WyQ==",
       "dependencies": {
         "graphql": "^15.5.0",
         "graphql-mapping-template": "4.20.15",
@@ -15772,7 +15778,7 @@
     },
     "packages/data-schema": {
       "name": "@aws-amplify/data-schema",
-      "version": "0.14.9",
+      "version": "0.14.10",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*",
@@ -15806,7 +15812,7 @@
       "version": "0.0.7",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-amplify/graphql-generator": "^0.2.4",
+        "@aws-amplify/graphql-generator": "^0.4.0-gen2-release-0411.0",
         "rxjs": "^7.8.1"
       },
       "devDependencies": {

--- a/packages/integration-tests/__tests__/defined-behavior/1-patterns/__snapshots__/read-data.ts.snap
+++ b/packages/integration-tests/__tests__/defined-behavior/1-patterns/__snapshots__/read-data.ts.snap
@@ -35,7 +35,7 @@ exports[`Read application data Fetch only the data you need with custom selectio
     {
       "authMode": undefined,
       "authToken": undefined,
-      "query": "query($id: ID!) { getBlog(id: $id) { author { email } publication { company { location { city } } } content { items { id title description blogId createdAt updatedAt blogContentId } } } }",
+      "query": "query($id: ID!) { getBlog(id: $id) { author { email } publication { company { location { city } } } content { items { id title description blogId createdAt updatedAt } } } }",
       "variables": {
         "id": "<MY_BLOG_ID>",
       },
@@ -114,7 +114,7 @@ exports[`Read application data TypeScript type helpers for Amplify Data part 2 1
     {
       "authMode": undefined,
       "authToken": undefined,
-      "query": "query($filter: ModelPostFilterInput,$limit: Int,$nextToken: String) { listPosts(filter: $filter,limit: $limit,nextToken: $nextToken) { items { content author comments { items { id content author postId createdAt updatedAt postCommentsId } } } nextToken __typename } }",
+      "query": "query($filter: ModelPostFilterInput,$limit: Int,$nextToken: String) { listPosts(filter: $filter,limit: $limit,nextToken: $nextToken) { items { content author comments { items { id content author postId createdAt updatedAt } } } nextToken __typename } }",
       "variables": {},
     },
     {},

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -8,7 +8,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aws-amplify/graphql-generator": "^0.2.4",
+    "@aws-amplify/graphql-generator": "^0.4.0-gen2-release-0411.0",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
*Description of changes:*
* Use tagged release `@aws-amplify/graphql-generator@0.4.0-gen2-release-0411.0` in `integration-tests` to validate modelgen changes with `references` support
* Update data-client snapshots

Issue to track updating the dep back to `latest` after the modelgen changes are released there: https://github.com/aws-amplify/amplify-api-next/issues/164

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
