### PR TITLE
chore: fix tsconfig module resolution settings

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,9 @@
     "incremental": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
-    "noErrorTruncation": true // prevents truncatation when hovering over type in VSCode
+    "noErrorTruncation": true, // prevents truncatation when hovering over type in VSCode
+    "module": "esnext",
+    "moduleResolution": "bundler"
   },
   "exclude": ["**/node_modules", "**/dist", "__tests__"]
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The IDE is currently unable to find modules, due to missing tsconfig settings. Build works fine presumably because rolloup exclusively uses settings from its own config at runtime

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
