### PR TITLE
chore: bump minor and publish data-schema changes

### DIFF
--- a/.changeset/silent-onions-own.md
+++ b/.changeset/silent-onions-own.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/data-schema": minor
+---
+
+bump minor in data-schema; missed in previous PR

--- a/package-lock.json
+++ b/package-lock.json
@@ -15780,7 +15780,7 @@
     },
     "packages/data-schema-types": {
       "name": "@aws-amplify/data-schema-types",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/plugin-types": "^0.9.0-beta.1",
@@ -15815,7 +15815,7 @@
       }
     },
     "packages/integration-tests": {
-      "version": "0.0.8",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/graphql-generator": "^0.4.0-gen2-release-0411.0",


### PR DESCRIPTION
Previous PR changeset [did not include a version bump for data-schema](https://github.com/aws-amplify/amplify-api-next/pull/145/files#diff-23357797879c30c497d5bc94f2661af0f9934ad4a135fc66a49c50ccbbf20ea7R2-R3), so changes have not been published.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
