### PR TITLE
fix(data-schema): custom types referenced by custom operations inherit auth configuration

### DIFF
--- a/packages/data-schema/__tests__/CustomOperations.test.ts
+++ b/packages/data-schema/__tests__/CustomOperations.test.ts
@@ -1101,7 +1101,7 @@ describe('custom operations + custom type auth inheritance', () => {
     expect(result).toMatchSnapshot();
     expect(result).toEqual(
       expect.stringContaining(
-        'type QueryReturn @aws_cognito_user_pools @aws_api_key',
+        'type QueryReturn @aws_api_key @aws_cognito_user_pools',
       ),
     );
   });

--- a/packages/data-schema/__tests__/__snapshots__/ClientSchema.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/ClientSchema.test.ts.snap
@@ -136,7 +136,7 @@ exports[`custom operations for an rds schema sql schema rename 1`] = `
 `;
 
 exports[`custom operations for an rds schema sql schema rename multiple models 1`] = `
-"type RenamedComment @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+"type tags @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
 {
   id: String! @primaryKey
   title: String
@@ -150,7 +150,7 @@ type RenamedPost @model(timestamps: null) @auth(rules: [{allow: public, provider
   author: String
 }
 
-type tags @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+type RenamedComment @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
 {
   id: String! @primaryKey
   title: String
@@ -353,7 +353,22 @@ exports[`schema auth rules global public auth - multiple models 1`] = `
   "functionSlots": [],
   "jsFunctions": [],
   "lambdaFunctions": {},
-  "schema": "type D @model @auth(rules: [{allow: public, provider: apiKey}])
+  "schema": "type A @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  field: String
+}
+
+type B @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  field: AWSJSON
+}
+
+type C @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  d: D @hasOne(references: ["cId"])
+}
+
+type D @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   can: Int
   you: Boolean
@@ -364,21 +379,6 @@ exports[`schema auth rules global public auth - multiple models 1`] = `
   tired: DTired
   cId: ID
   c: C @belongsTo(references: ["cId"])
-}
-
-type C @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  d: D @hasOne(references: ["cId"])
-}
-
-type B @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  field: AWSJSON
-}
-
-type A @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  field: String
 }
 
 enum DTired {
@@ -430,21 +430,57 @@ exports[`schema auth rules prefers model auth over global auth public auth on mo
 `;
 
 exports[`schema generation with relationships 1`] = `
-"type CPKReciprocalHasManyChild @model @auth(rules: [{allow: public, provider: apiKey}])
+"type BoringParent @model @auth(rules: [{allow: public, provider: apiKey}])
 {
-  CPKReciprocalHasManyChildIdFieldA: ID! @primaryKey(sortKeyFields: ["CPKReciprocalHasManyChildIdFieldB"])
-  CPKReciprocalHasManyChildIdFieldB: ID!
-  value: String
-  CPKParentIdFieldA: ID!
-  CPKParentIdFieldB: ID!
-  parent: CPKParent @belongsTo(references: ["CPKParentIdFieldA","CPKParentIdFieldB"])
+  childNormal: BoringChild @hasOne(references: ["boringParentId"])
+  childReciprocal: BoringReciprocalChild @hasOne(references: ["boringParentId"])
+  childHasManyNormal: [BoringHasManyChild] @hasMany(references: ["boringParentId"])
+  childHasManyReciprocal: [ReciprocalHasManyChild] @hasMany(references: ["boringParentId"])
 }
 
-type CPKHasManyChild @model @auth(rules: [{allow: public, provider: apiKey}])
+type BoringChild @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   value: String
-  CPKHasManyChildIdFieldA: ID! @primaryKey(sortKeyFields: ["CPKHasManyChildIdFieldB"])
-  CPKHasManyChildIdFieldB: ID!
+  boringParentId: ID
+  boringParent: BoringParent @belongsTo(references: ["boringParentId"])
+}
+
+type BoringReciprocalChild @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  value: String
+  boringParentId: ID
+  parent: BoringParent @belongsTo(references: ["boringParentId"])
+}
+
+type BoringHasManyChild @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  value: String
+  boringParentId: ID
+  parent: BoringParent @belongsTo(references: ["boringParentId"])
+}
+
+type ReciprocalHasManyChild @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  value: String
+  boringParentId: ID
+  parent: BoringParent @belongsTo(references: ["boringParentId"])
+}
+
+type CPKParent @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  CPKParentIdFieldA: ID! @primaryKey(sortKeyFields: ["CPKParentIdFieldB"])
+  CPKParentIdFieldB: ID!
+  childNormal: CPKChild @hasOne(references: ["CPKParentIdFieldA","CPKParentIdFieldB"])
+  childReciprocal: CPKReciprocalChild @hasOne(references: ["CPKParentIdFieldA","CPKParentIdFieldB"])
+  childHasManyNormal: [CPKHasManyChild] @hasMany(references: ["CPKParentIdFieldA","CPKParentIdFieldB"])
+  childHasManyReciprocal: [CPKReciprocalHasManyChild] @hasMany(references: ["CPKParentIdFieldA","CPKParentIdFieldB"])
+}
+
+type CPKChild @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  value: String
+  CPKChildIdFieldA: ID! @primaryKey(sortKeyFields: ["CPKChildIdFieldB"])
+  CPKChildIdFieldB: ID!
   CPKParentIdFieldA: ID
   CPKParentIdFieldB: ID
   cpkParent: CPKParent @belongsTo(references: ["CPKParentIdFieldA","CPKParentIdFieldB"])
@@ -460,59 +496,23 @@ type CPKReciprocalChild @model @auth(rules: [{allow: public, provider: apiKey}])
   value: String
 }
 
-type CPKChild @model @auth(rules: [{allow: public, provider: apiKey}])
+type CPKHasManyChild @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   value: String
-  CPKChildIdFieldA: ID! @primaryKey(sortKeyFields: ["CPKChildIdFieldB"])
-  CPKChildIdFieldB: ID!
+  CPKHasManyChildIdFieldA: ID! @primaryKey(sortKeyFields: ["CPKHasManyChildIdFieldB"])
+  CPKHasManyChildIdFieldB: ID!
   CPKParentIdFieldA: ID
   CPKParentIdFieldB: ID
   cpkParent: CPKParent @belongsTo(references: ["CPKParentIdFieldA","CPKParentIdFieldB"])
 }
 
-type CPKParent @model @auth(rules: [{allow: public, provider: apiKey}])
+type CPKReciprocalHasManyChild @model @auth(rules: [{allow: public, provider: apiKey}])
 {
-  CPKParentIdFieldA: ID! @primaryKey(sortKeyFields: ["CPKParentIdFieldB"])
+  CPKReciprocalHasManyChildIdFieldA: ID! @primaryKey(sortKeyFields: ["CPKReciprocalHasManyChildIdFieldB"])
+  CPKReciprocalHasManyChildIdFieldB: ID!
+  value: String
+  CPKParentIdFieldA: ID!
   CPKParentIdFieldB: ID!
-  childNormal: CPKChild @hasOne(references: ["CPKParentIdFieldA","CPKParentIdFieldB"])
-  childReciprocal: CPKReciprocalChild @hasOne(references: ["CPKParentIdFieldA","CPKParentIdFieldB"])
-  childHasManyNormal: [CPKHasManyChild] @hasMany(references: ["CPKParentIdFieldA","CPKParentIdFieldB"])
-  childHasManyReciprocal: [CPKReciprocalHasManyChild] @hasMany(references: ["CPKParentIdFieldA","CPKParentIdFieldB"])
-}
-
-type ReciprocalHasManyChild @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  value: String
-  boringParentId: ID
-  parent: BoringParent @belongsTo(references: ["boringParentId"])
-}
-
-type BoringHasManyChild @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  value: String
-  boringParentId: ID
-  parent: BoringParent @belongsTo(references: ["boringParentId"])
-}
-
-type BoringReciprocalChild @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  value: String
-  boringParentId: ID
-  parent: BoringParent @belongsTo(references: ["boringParentId"])
-}
-
-type BoringChild @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  value: String
-  boringParentId: ID
-  boringParent: BoringParent @belongsTo(references: ["boringParentId"])
-}
-
-type BoringParent @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  childNormal: BoringChild @hasOne(references: ["boringParentId"])
-  childReciprocal: BoringReciprocalChild @hasOne(references: ["boringParentId"])
-  childHasManyNormal: [BoringHasManyChild] @hasMany(references: ["boringParentId"])
-  childHasManyReciprocal: [ReciprocalHasManyChild] @hasMany(references: ["boringParentId"])
+  parent: CPKParent @belongsTo(references: ["CPKParentIdFieldA","CPKParentIdFieldB"])
 }"
 `;

--- a/packages/data-schema/__tests__/__snapshots__/CustomOperations.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/CustomOperations.test.ts.snap
@@ -445,8 +445,8 @@ type Query {
 }
 
 type Subscription {
-  onLikePost: Post @function(name: "myFunc") @aws_subscribe(mutations: ["updatePost"]) @auth(rules: [{allow: public, provider: apiKey}])
   onCreatePost: Post @function(name: "myFunc") @aws_subscribe(mutations: ["createPost"]) @auth(rules: [{allow: public, provider: apiKey}])
+  onLikePost: Post @function(name: "myFunc") @aws_subscribe(mutations: ["updatePost"]) @auth(rules: [{allow: public, provider: apiKey}])
 }"
 `;
 
@@ -491,14 +491,14 @@ type Query {
 `;
 
 exports[`custom operations + custom type auth inheritance top-level custom type inherits combined auth rules from referencing ops 1`] = `
-"type QueryReturn @aws_cognito_user_pools @aws_api_key
+"type QueryReturn @aws_api_key @aws_cognito_user_pools
 {
   fieldA: String
   fieldB: Int
 }
 
 type Query {
-  myMutation: QueryReturn @function(name: "myFn") @auth(rules: [{allow: private}])
   myQuery: QueryReturn @function(name: "myFn") @auth(rules: [{allow: public, provider: apiKey}])
+  myMutation: QueryReturn @function(name: "myFn") @auth(rules: [{allow: private}])
 }"
 `;

--- a/packages/data-schema/__tests__/__snapshots__/CustomType.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/CustomType.test.ts.snap
@@ -40,14 +40,14 @@ type Location
 `;
 
 exports[`CustomType transform Explicit CustomType nests explicit CustomType 1`] = `
-"enum PostStatus {
-  unpublished
-  published
-}
-
-type Post @model @auth(rules: [{allow: public, provider: apiKey}])
+"type Post @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   meta: Meta
+}
+
+enum PostStatus {
+  unpublished
+  published
 }
 
 type Meta 
@@ -63,14 +63,14 @@ type AltMeta
 `;
 
 exports[`CustomType transform Explicit CustomType nests explicit enum 1`] = `
-"enum PostStatus {
-  unpublished
-  published
-}
-
-type Post @model @auth(rules: [{allow: public, provider: apiKey}])
+"type Post @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   meta: Meta
+}
+
+enum PostStatus {
+  unpublished
+  published
 }
 
 type Meta 
@@ -158,14 +158,14 @@ enum PostMetaStatus {
 `;
 
 exports[`CustomType transform Implicit CustomType nests explicit enum 1`] = `
-"enum PostStatus {
-  unpublished
-  published
-}
-
-type Post @model @auth(rules: [{allow: public, provider: apiKey}])
+"type Post @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   meta: PostMeta
+}
+
+enum PostStatus {
+  unpublished
+  published
 }
 
 type PostMeta 

--- a/packages/data-schema/__tests__/__snapshots__/EnumType.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/EnumType.test.ts.snap
@@ -1,41 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EnumType transform Explicit Enum - auth 1`] = `
-"enum AccessLevel {
+"type File @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  accessLevel: AccessLevel @auth(rules: [{allow: owner, ownerField: "owner"}])
+}
+
+enum AccessLevel {
   public
   protected
   private
-}
-
-type File @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  accessLevel: AccessLevel @auth(rules: [{allow: owner, ownerField: "owner"}])
 }"
 `;
 
 exports[`EnumType transform Explicit Enum - required 1`] = `
-"enum AccessLevel {
+"type File @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  accessLevel: AccessLevel!
+}
+
+enum AccessLevel {
   public
   protected
   private
-}
-
-type File @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  accessLevel: AccessLevel!
 }"
 `;
 
 exports[`EnumType transform Explicit Enum 1`] = `
-"enum AccessLevel {
+"type File @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  accessLevel: AccessLevel
+}
+
+enum AccessLevel {
   public
   protected
   private
-}
-
-type File @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  accessLevel: AccessLevel
 }"
 `;
 

--- a/packages/data-schema/__tests__/__snapshots__/ModelIndex.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/ModelIndex.test.ts.snap
@@ -31,31 +31,31 @@ enum TodoStatus {
 `;
 
 exports[`secondary index schema generation generates correct schema for using a.ref() (refer to an enum) as the partition key 1`] = `
-"enum TodoStatus {
-  open
-  in_progress
-  completed
-}
-
-type Todo @model @auth(rules: [{allow: public, provider: apiKey}])
+"type Todo @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   title: String!
   content: String
   status: TodoStatus @index(sortKeyFields: ["title"], queryField: "listTodoByStatusAndTitle")
+}
+
+enum TodoStatus {
+  open
+  in_progress
+  completed
 }"
 `;
 
 exports[`secondary index schema generation generates correct schema for using a.ref() (refer to an enum) as the sort key 1`] = `
-"enum TodoStatus {
-  open
-  in_progress
-  completed
-}
-
-type Todo @model @auth(rules: [{allow: public, provider: apiKey}])
+"type Todo @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   title: String! @index(sortKeyFields: ["status"], queryField: "listTodoByTitleAndStatus")
   content: String
   status: TodoStatus
+}
+
+enum TodoStatus {
+  open
+  in_progress
+  completed
 }"
 `;

--- a/packages/data-schema/__tests__/__snapshots__/ModelRelationalField.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/ModelRelationalField.test.ts.snap
@@ -1,50 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`schema generation with relationships ddb hasOne / belongsTo explicitly defined reference field on related model is supported 1`] = `
-"type Project @model @auth(rules: [{allow: public, provider: apiKey}])
+"type Team @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  motto: String
+  project: Project @hasOne(references: ["teamId"])
+}
+
+type Project @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   name: String
   teamId: ID
   team: Team @belongsTo(references: ["teamId"])
-}
-
-type Team @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  motto: String
-  project: Project @hasOne(references: ["teamId"])
 }"
 `;
 
 exports[`schema generation with relationships ddb masMany / belongsTo explicitly defined reference field on related model is supported 1`] = `
-"type Member @model @auth(rules: [{allow: public, provider: apiKey}])
+"type Team @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  motto: String
+  members: [Member] @hasMany(references: ["teamId"])
+}
+
+type Member @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   name: String
   teamId: ID
   team: Team @belongsTo(references: ["teamId"])
-}
-
-type Team @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  motto: String
-  members: [Member] @hasMany(references: ["teamId"])
 }"
 `;
 
 exports[`schema generation with relationships ddb masMany / belongsTo partition key + sort key is supported 1`] = `
-"type Member @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  name: String
-  teamId: ID
-  teamSk: ID
-  team: Team @belongsTo(references: ["teamId","teamSk"])
-}
-
-type Team @model @auth(rules: [{allow: public, provider: apiKey}])
+"type Team @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   id: ID! @primaryKey(sortKeyFields: ["sk"])
   sk: ID!
   motto: String
   members: [Member] @hasMany(references: ["teamId","teamSk"])
+}
+
+type Member @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  name: String
+  teamId: ID
+  teamSk: ID
+  team: Team @belongsTo(references: ["teamId","teamSk"])
 }"
 `;
 
@@ -56,7 +56,7 @@ exports[`schema generation with relationships heterogenous data source relations
   members: [Member] @hasMany(references: ["teamId"])
   project: Project @hasOne(references: ["teamId"])
 }
-type Member @model @auth(rules: [{allow: public, provider: apiKey}])
+type Project @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   id: ID! @primaryKey
   name: String
@@ -64,7 +64,7 @@ type Member @model @auth(rules: [{allow: public, provider: apiKey}])
   team: Team @belongsTo(references: ["teamId"])
 }
 
-type Project @model @auth(rules: [{allow: public, provider: apiKey}])
+type Member @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   id: ID! @primaryKey
   name: String
@@ -74,11 +74,11 @@ type Project @model @auth(rules: [{allow: public, provider: apiKey}])
 `;
 
 exports[`schema generation with relationships relationships 1`] = `
-"type Member @model @auth(rules: [{allow: public, provider: apiKey}])
+"type Team @model @auth(rules: [{allow: public, provider: apiKey}])
 {
-  name: String
-  teamId: ID
-  team: Team @belongsTo(references: ["teamId"])
+  motto: String
+  members: [Member] @hasMany(references: ["teamId"])
+  project: Project @hasOne(references: ["teamId"])
 }
 
 type Project @model @auth(rules: [{allow: public, provider: apiKey}])
@@ -88,21 +88,21 @@ type Project @model @auth(rules: [{allow: public, provider: apiKey}])
   team: Team @belongsTo(references: ["teamId"])
 }
 
-type Team @model @auth(rules: [{allow: public, provider: apiKey}])
+type Member @model @auth(rules: [{allow: public, provider: apiKey}])
 {
-  motto: String
-  members: [Member] @hasMany(references: ["teamId"])
-  project: Project @hasOne(references: ["teamId"])
+  name: String
+  teamId: ID
+  team: Team @belongsTo(references: ["teamId"])
 }"
 `;
 
 exports[`schema generation with relationships sql references 1`] = `
-"type Member @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+"type Team @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
 {
   id: ID! @primaryKey
-  name: String
-  teamId: ID
-  team: Team @belongsTo(references: ["teamId"])
+  motto: String
+  members: [Member] @hasMany(references: ["teamMembersId"])
+  project: Project @hasOne(references: ["teamProjectId"])
 }
 
 type Project @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
@@ -113,11 +113,11 @@ type Project @model(timestamps: null) @auth(rules: [{allow: public, provider: ap
   team: Team @belongsTo(references: ["teamId"])
 }
 
-type Team @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+type Member @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
 {
   id: ID! @primaryKey
-  motto: String
-  members: [Member] @hasMany(references: ["teamMembersId"])
-  project: Project @hasOne(references: ["teamProjectId"])
+  name: String
+  teamId: ID
+  team: Team @belongsTo(references: ["teamId"])
 }"
 `;

--- a/packages/data-schema/__tests__/__snapshots__/RDSModelSchema.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/RDSModelSchema.test.ts.snap
@@ -1,77 +1,77 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RDSModelSchema .setRelationships() modifier generates expected schema for bidirectional hasMany<->belongsTo 1`] = `
-"type Blog @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
-{
-  title: String!
-  description: String
-  childPosts: [Post] @hasMany(references: ["parentBlogId"])
-}
-
-type Post @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+"type Post @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
 {
   title: String!
   content: String
   parentBlogId: String
   parentBlog: Blog @belongsTo(references: ["parentBlogId"])
-}"
-`;
-
-exports[`RDSModelSchema .setRelationships() modifier generates expected schema for bidirectional hasOne<->belongsTo 1`] = `
-"type Account @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
-{
-  email: String!
-  supplierId: String
-  supplier: Supplier @belongsTo(references: ["supplierId"])
 }
 
-type Supplier @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
-{
-  name: String!
-  account: Account @hasOne(references: ["supplierIds"])
-}"
-`;
-
-exports[`RDSModelSchema .setRelationships() modifier generates expected schema for unidirectional belongsTo 1`] = `
-"type Account @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
-{
-  email: String!
-  supplierId: String
-  supplier: Supplier @belongsTo(references: ["supplierId"])
-}
-
-type Supplier @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
-{
-  name: String!
-}"
-`;
-
-exports[`RDSModelSchema .setRelationships() modifier generates expected schema for unidirectional hasMany 1`] = `
-"type Blog @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+type Blog @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
 {
   title: String!
   description: String
   childPosts: [Post] @hasMany(references: ["parentBlogId"])
+}"
+`;
+
+exports[`RDSModelSchema .setRelationships() modifier generates expected schema for bidirectional hasOne<->belongsTo 1`] = `
+"type Supplier @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+{
+  name: String!
+  account: Account @hasOne(references: ["supplierIds"])
 }
 
-type Post @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+type Account @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+{
+  email: String!
+  supplierId: String
+  supplier: Supplier @belongsTo(references: ["supplierId"])
+}"
+`;
+
+exports[`RDSModelSchema .setRelationships() modifier generates expected schema for unidirectional belongsTo 1`] = `
+"type Supplier @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+{
+  name: String!
+}
+
+type Account @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+{
+  email: String!
+  supplierId: String
+  supplier: Supplier @belongsTo(references: ["supplierId"])
+}"
+`;
+
+exports[`RDSModelSchema .setRelationships() modifier generates expected schema for unidirectional hasMany 1`] = `
+"type Post @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
 {
   title: String!
   content: String
   parentBlogId: String
+}
+
+type Blog @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+{
+  title: String!
+  description: String
+  childPosts: [Post] @hasMany(references: ["parentBlogId"])
 }"
 `;
 
 exports[`RDSModelSchema .setRelationships() modifier generates expected schema for unidirectional hasOne 1`] = `
-"type Account @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
-{
-  email: String!
-  supplierId: String
-}
-
-type Supplier @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+"type Supplier @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
 {
   name: String!
   account: Account @hasOne(references: ["supplierId"])
+}
+
+type Account @model(timestamps: null) @auth(rules: [{allow: public, provider: apiKey}])
+{
+  email: String!
+  supplierId: String
 }"
 `;

--- a/packages/data-schema/src/SchemaProcessor.ts
+++ b/packages/data-schema/src/SchemaProcessor.ts
@@ -1105,7 +1105,10 @@ const getRefTypeForSchema = (schema: InternalSchema) => {
 const sortTopLevelTypes = (topLevelTypes: [string, any][]) => {
   return topLevelTypes.sort(
     ([_typeNameA, typeDefA], [_typeNameB, typeDefB]) => {
-      if (isCustomType(typeDefA) && isCustomType(typeDefB)) {
+      if (
+        (isCustomType(typeDefA) && isCustomType(typeDefB)) ||
+        (!isCustomType(typeDefA) && !isCustomType(typeDefB))
+      ) {
         return 0;
       } else if (isCustomType(typeDefA) && !isCustomType(typeDefB)) {
         return 1;


### PR DESCRIPTION
*Issue #, if available:*
Resolves https://github.com/aws-amplify/amplify-category-api/issues/2486

*Description of changes:*
* Fixes bug where custom types were inaccessible in custom operation return types during resolution due to lacking auth rules
* adds support for inline `a.enum` return types for custom operations (previously, only ref'd enums worked)
* adds error messaging when a custom operation with `handler.custom` (js resolver) tries to use identityPool-based auth

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
