### PR TITLE
chore: push tags after publishing main

### DIFF
--- a/.changeset/dirty-hairs-approve.md
+++ b/.changeset/dirty-hairs-approve.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/data-schema": patch
+---
+
+cleanup

--- a/.github/workflows/callable-npm-publish-release.yml
+++ b/.github/workflows/callable-npm-publish-release.yml
@@ -32,9 +32,14 @@ jobs:
           git config --global user.email $GITHUB_EMAIL
           git config --global user.name $GITHUB_USER
 
+      - name: Update lockfile with newly published version
+        working-directory: ./amplify-api-next
+        run: npm i
+
       - name: Commit version and changelog
         working-directory: ./amplify-api-next
         run: |
           git add .
           git commit -m "release: publish [ci skip]"
           git push origin main
+          git push --follow-tags

--- a/package-lock.json
+++ b/package-lock.json
@@ -15991,7 +15991,7 @@
     },
     "packages/data-schema": {
       "name": "@aws-amplify/data-schema",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/data-schema-types": "*",


### PR DESCRIPTION
*Description of changes:*
Minor changes to release workflow

1. Updates lockfile after publish
2. Push tags to origin

Note: includes a changeset to validate these changes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
