### PR TITLE
fix: nested custom types inherit custom op's auth

### DIFF
--- a/.changeset/odd-deers-sniff.md
+++ b/.changeset/odd-deers-sniff.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/data-schema': patch
+---
+
+fix: nested custom types inherit custom op's auth

--- a/packages/data-schema/__tests__/__snapshots__/CustomOperations.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/CustomOperations.test.ts.snap
@@ -462,6 +462,32 @@ type Query {
 }"
 `;
 
+exports[`custom operations + custom type auth inheritance nested custom types inherit auth rules from top-level referencing op 1`] = `
+"type MyQueryReturnType @aws_api_key
+{
+  fieldA: String
+  fieldB: Int
+  nestedCustomType: MyQueryReturnTypeNestedCustomType
+}
+
+type MyQueryReturnTypeNestedCustomType @aws_api_key
+{
+  nestedA: String
+  nestedB: String
+  grandChild: MyQueryReturnTypeNestedCustomTypeGrandChild
+}
+
+type MyQueryReturnTypeNestedCustomTypeGrandChild @aws_api_key
+{
+  grandA: String
+  grandB: String
+}
+
+type Query {
+  myQuery: MyQueryReturnType @function(name: "myFn") @auth(rules: [{allow: public, provider: apiKey}])
+}"
+`;
+
 exports[`custom operations + custom type auth inheritance op returns top-level custom type with 1 auth mode 1`] = `
 "type QueryReturn @aws_api_key
 {
@@ -492,6 +518,60 @@ type Query {
 
 exports[`custom operations + custom type auth inheritance top-level custom type inherits combined auth rules from referencing ops 1`] = `
 "type QueryReturn @aws_api_key @aws_cognito_user_pools
+{
+  fieldA: String
+  fieldB: Int
+}
+
+type Query {
+  myQuery: QueryReturn @function(name: "myFn") @auth(rules: [{allow: public, provider: apiKey}])
+  myMutation: QueryReturn @function(name: "myFn") @auth(rules: [{allow: private}])
+}"
+`;
+
+exports[`custom operations + custom type auth inheritance top-level custom type with nested implicit and explicit custom types inherits combined auth rules from referencing ops 1`] = `
+"type QueryReturn @aws_api_key @aws_cognito_user_pools
+{
+  fieldA: String
+  fieldB: Int
+  nested: QueryReturnNested
+}
+
+type LevelTwo @aws_api_key @aws_cognito_user_pools
+{
+  fieldA: String
+  fieldB: Int
+}
+
+type QueryReturnNested @aws_api_key @aws_cognito_user_pools
+{
+  fieldA: String
+  fieldB: Int
+  nested: LevelTwo
+}
+
+type Query {
+  myQuery: QueryReturn @function(name: "myFn") @auth(rules: [{allow: public, provider: apiKey}])
+  myMutation: QueryReturn @function(name: "myFn") @auth(rules: [{allow: private}])
+}"
+`;
+
+exports[`custom operations + custom type auth inheritance top-level custom type with nested top-level custom types inherits combined auth rules from referencing ops 1`] = `
+"type QueryReturn @aws_api_key @aws_cognito_user_pools
+{
+  fieldA: String
+  fieldB: Int
+  nested: LevelOne
+}
+
+type LevelOne @aws_api_key @aws_cognito_user_pools
+{
+  fieldA: String
+  fieldB: Int
+  nested: LevelTwo
+}
+
+type LevelTwo @aws_api_key @aws_cognito_user_pools
 {
   fieldA: String
   fieldB: Int

--- a/packages/data-schema/src/SchemaProcessor.ts
+++ b/packages/data-schema/src/SchemaProcessor.ts
@@ -1245,13 +1245,29 @@ const schemaPreprocessor = (
           getRefType,
         );
 
+        topLevelTypes.push(...implicitTypes);
+
         mergeCustomTypeAuthRules(
           customTypeInheritedAuthRules,
           customTypeAuthRules,
         );
-        Object.assign(lambdaFunctions, lambdaFunctionDefinition);
 
-        topLevelTypes.push(...implicitTypes);
+        if (customTypeAuthRules) {
+          const nestedCustomTypeNames = extractNestedCustomTypeNames(
+            customTypeAuthRules,
+            topLevelTypes,
+            getRefType,
+          );
+
+          for (const nestedCustomType of nestedCustomTypeNames) {
+            mergeCustomTypeAuthRules(customTypeInheritedAuthRules, {
+              typeName: nestedCustomType,
+              authRules: customTypeAuthRules.authRules, // apply the same auth rules as the top-level custom type
+            });
+          }
+        }
+
+        Object.assign(lambdaFunctions, lambdaFunctionDefinition);
 
         if (jsFunctionForField) {
           jsFunctions.push(jsFunctionForField);
@@ -1664,6 +1680,55 @@ function generateCustomOperationTypes({
   }
 
   return types;
+}
+
+function extractNestedCustomTypeNames(
+  customTypeAuthRules: CustomTypeAuthRules,
+  topLevelTypes: [string, any][],
+  getRefType: ReturnType<typeof getRefTypeForSchema>,
+): string[] {
+  if (!customTypeAuthRules) {
+    return [];
+  }
+
+  const [_, customTypeDef] = topLevelTypes.find(
+    ([topLevelTypeName]) => customTypeAuthRules.typeName === topLevelTypeName,
+  )!;
+
+  // traverse the custom type's fields and extract any nested custom type names.
+  // Those nested custom types also inherit the custom op's auth configuration.
+  // Supports both inline custom types and refs to custom types
+  const traverseCustomTypeFields = (
+    name: string,
+    typeDef: any,
+    namesList: string[] = [],
+  ) => {
+    const fields = typeDef.data.fields as Record<string, any>;
+
+    for (const [fieldName, fieldDef] of Object.entries(fields)) {
+      if (isCustomType(fieldDef)) {
+        const customTypeName = `${capitalize(name)}${capitalize(fieldName)}`;
+        namesList.push(customTypeName);
+        traverseCustomTypeFields(customTypeName, fieldDef, namesList);
+      } else if (isRefField(fieldDef)) {
+        const refType = getRefType(fieldDef.data.link, name);
+
+        if (refType.type === 'CustomType') {
+          namesList.push(fieldDef.data.link);
+          traverseCustomTypeFields(fieldDef.data.link, refType.def, namesList);
+        }
+      }
+    }
+
+    return namesList;
+  };
+
+  const nestedCustomTypeNames = traverseCustomTypeFields(
+    customTypeAuthRules.typeName,
+    customTypeDef,
+  );
+
+  return nestedCustomTypeNames;
 }
 
 /**


### PR DESCRIPTION
*Description of changes:*
This PR fixes a bug where nested Custom Types that are part of a Custom Operation's return type are inaccessible during resolution. 

This is a follow up to https://github.com/aws-amplify/amplify-api-next/pull/204 where we fixed this for top-level custom types. 

Now we also do a DFS traversal of the top-level custom type's fields and apply the same auth configuration to all of the nested custom types to ensure the custom operation can successfully resolve the return type during execution in the data plane.

Supports nested inline custom types, as well as refs to custom types, or any combination of nested and ref'd custom types (see added tests).

Example
```ts
const s = a.schema({
  myQuery: a
    .query()
    .handler(a.handler.function('myFn'))
    .returns(a.ref('QueryReturn'))
    .authorization((allow) => allow.publicApiKey()),
  myMutation: a
    .query()
    .handler(a.handler.function('myFn'))
    .returns(a.ref('QueryReturn'))
    .authorization((allow) => allow.authenticated()),
  QueryReturn: a.customType({
    fieldA: a.string(),
    fieldB: a.integer(),
    nested: a.customType({
      fieldA: a.string(),
      fieldB: a.integer(),
      nested: a.ref('LevelTwo'),
    }),
  }),
  LevelTwo: a.customType({
    fieldA: a.string(),
    fieldB: a.integer(),
  }),
});
```
Is transformed to this Model Schema
```gql
type QueryReturn @aws_api_key @aws_cognito_user_pools
{
  fieldA: String
  fieldB: Int
  nested: QueryReturnNested
}

type LevelTwo @aws_api_key @aws_cognito_user_pools
{
  fieldA: String
  fieldB: Int
}

type QueryReturnNested @aws_api_key @aws_cognito_user_pools
{
  fieldA: String
  fieldB: Int
  nested: LevelTwo
}

type Query {
  myQuery: QueryReturn @function(name: "myFn") @auth(rules: [{allow: public, provider: apiKey}])
  myMutation: QueryReturn @function(name: "myFn") @auth(rules: [{allow: private}])
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
