### PR TITLE
fix return types of create, update, delete operations on SSR clients

### DIFF
--- a/.changeset/rude-nails-build.md
+++ b/.changeset/rude-nails-build.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/data-schema": patch
+---
+
+fix return types of create, update, delete operations on SSR clients

--- a/packages/data-schema/__tests__/runtime/ssr-types.test-d.ts
+++ b/packages/data-schema/__tests__/runtime/ssr-types.test-d.ts
@@ -1,0 +1,161 @@
+import { a, ClientSchema } from '../../src/index';
+import {
+  ClientExtensions,
+  ClientExtensionsSSRCookies,
+  ClientExtensionsSSRRequest,
+} from '../../src/runtime/client/index';
+import { Expect, Equal } from '@aws-amplify/data-schema-types';
+
+describe('method return types', () => {
+  const schema = a
+    .schema({
+      Parent: a.model({
+        name: a.string(),
+        children: a.hasMany('Child', 'parentId'),
+      }),
+      Child: a.model({
+        name: a.string(),
+        parentId: a.id(),
+        parent: a.belongsTo('Parent', 'parentId'),
+      }),
+      MyCustomType: a.customType({
+        value: a.string(),
+      }),
+      operate: a
+        .query()
+        .arguments({ id: a.string() })
+        .returns(a.ref('MyCustomType'))
+        .authorization((allow) => [allow.publicApiKey()])
+        .handler(a.handler.function('asdf')),
+    })
+    .authorization((allow) => [allow.publicApiKey()]);
+
+  type Schema = ClientSchema<typeof schema>;
+
+  const normalClient = {} as ClientExtensions<Schema>;
+  const cookiesClient = {} as ClientExtensionsSSRCookies<Schema>;
+  const requestClient = {} as ClientExtensionsSSRRequest<Schema>;
+
+  test('create request results match normal client', async () => {
+    const { data: normalData } = await normalClient.models.Parent.create({});
+    const { data: cookiesData } = await cookiesClient.models.Parent.create({});
+    const { data: requestData } = await requestClient.models.Parent.create(
+      {} as any,
+      {},
+    );
+
+    type _testCookiesClient = Expect<
+      Equal<typeof cookiesData, typeof normalData>
+    >;
+
+    type _testRequestClient = Expect<
+      Equal<typeof requestData, typeof normalData>
+    >;
+  });
+
+  test('update request results match normal client', async () => {
+    const { data: normalData } = await normalClient.models.Parent.update({
+      id: 'some-id',
+    });
+    const { data: cookiesData } = await cookiesClient.models.Parent.update({
+      id: 'some-id',
+    });
+    const { data: requestData } = await requestClient.models.Parent.update(
+      {} as any,
+      { id: 'some-id' },
+    );
+
+    type _testCookiesClient = Expect<
+      Equal<typeof cookiesData, typeof normalData>
+    >;
+
+    type _testRequestClient = Expect<
+      Equal<typeof requestData, typeof normalData>
+    >;
+  });
+
+  test('delete request results match normal client', async () => {
+    const { data: normalData } = await normalClient.models.Parent.delete({
+      id: 'some-id',
+    });
+    const { data: cookiesData } = await cookiesClient.models.Parent.delete({
+      id: 'some-id',
+    });
+    const { data: requestData } = await requestClient.models.Parent.delete(
+      {} as any,
+      { id: 'some-id' },
+    );
+
+    type _testCookiesClient = Expect<
+      Equal<typeof cookiesData, typeof normalData>
+    >;
+
+    type _testRequestClient = Expect<
+      Equal<typeof requestData, typeof normalData>
+    >;
+  });
+
+  test('get request results match normal client', async () => {
+    const { data: normalData } = await normalClient.models.Parent.get({
+      id: 'some-id',
+    });
+    const { data: cookiesData } = await cookiesClient.models.Parent.get({
+      id: 'some-id',
+    });
+    const { data: requestData } = await requestClient.models.Parent.get(
+      {} as any,
+      {
+        id: 'some-id',
+      },
+    );
+
+    type _testCookiesClient = Expect<
+      Equal<typeof cookiesData, typeof normalData>
+    >;
+
+    type _testRequestClient = Expect<
+      Equal<typeof requestData, typeof normalData>
+    >;
+  });
+
+  test('list request results match normal client', async () => {
+    const { data: normalData } = await normalClient.models.Parent.list();
+    const { data: cookiesData } = await cookiesClient.models.Parent.list();
+    const { data: requestData } = await requestClient.models.Parent.list(
+      {} as any,
+    );
+
+    type _testCookiesClient = Expect<
+      Equal<typeof cookiesData, typeof normalData>
+    >;
+
+    type _testRequestClient = Expect<
+      Equal<typeof requestData, typeof normalData>
+    >;
+  });
+
+  test('custom operation results match normal client', async () => {
+    const { data: normalData } = await normalClient.queries.operate({
+      id: 'some-id',
+    });
+    const { data: cookiesData } = await cookiesClient.queries.operate({
+      id: 'some-id',
+    });
+    const { data: requestData } = await requestClient.queries.operate(
+      {} as any,
+      {
+        id: 'some-id',
+      },
+    );
+
+    type _testCookiesClient = Expect<
+      Equal<typeof cookiesData, typeof normalData>
+    >;
+
+    type _testRequestClient = Expect<
+      Equal<typeof requestData, typeof normalData>
+    >;
+  });
+
+  // Subscription type operations are omitted as they aren't supported in SSR contexts.
+});

--- a/packages/data-schema/__tests__/runtime/ssr-types.test.ts
+++ b/packages/data-schema/__tests__/runtime/ssr-types.test.ts
@@ -1,0 +1,5 @@
+import { expectTypeTestsToPassAsync } from 'jest-tsd'; // evaluates type defs in corresponding test-d.ts file
+
+it('should not produce static type errors', async () => {
+  await expectTypeTestsToPassAsync(__filename);
+});

--- a/packages/data-schema/src/runtime/client/index.ts
+++ b/packages/data-schema/src/runtime/client/index.ts
@@ -562,7 +562,7 @@ type ModelTypesSSRCookies<
       authToken?: string;
       headers?: CustomHeaders;
     },
-  ) => SingularReturnValue<Model>;
+  ) => SingularReturnValue<Model['type']>;
   update: (
     model: Model['updateType'],
     options?: {
@@ -570,7 +570,7 @@ type ModelTypesSSRCookies<
       authToken?: string;
       headers?: CustomHeaders;
     },
-  ) => SingularReturnValue<Model>;
+  ) => SingularReturnValue<Model['type']>;
   delete: (
     identifier: Model['deleteType'],
     options?: {
@@ -578,7 +578,7 @@ type ModelTypesSSRCookies<
       authToken?: string;
       headers?: CustomHeaders;
     },
-  ) => SingularReturnValue<Model>;
+  ) => SingularReturnValue<Model['type']>;
   get<SelectionSet extends ReadonlyArray<ModelPath<FlatModel>> = never[]>(
     identifier: Model['identifier'],
     options?: {
@@ -615,7 +615,7 @@ type ModelTypesSSRRequest<
       authToken?: string;
       headers?: CustomHeaders;
     },
-  ) => SingularReturnValue<Model>;
+  ) => SingularReturnValue<Model['type']>;
   update: (
     contextSpec: any,
     model: Model['updateType'],
@@ -624,7 +624,7 @@ type ModelTypesSSRRequest<
       authToken?: string;
       headers?: CustomHeaders;
     },
-  ) => SingularReturnValue<Model>;
+  ) => SingularReturnValue<Model['type']>;
   delete: (
     contextSpec: any,
     identifier: Model['deleteType'],
@@ -633,7 +633,7 @@ type ModelTypesSSRRequest<
       authToken?: string;
       headers?: CustomHeaders;
     },
-  ) => SingularReturnValue<Model>;
+  ) => SingularReturnValue<Model['type']>;
   get<SelectionSet extends ReadonlyArray<ModelPath<FlatModel>> = never[]>(
     contextSpec: any,
     identifier: Model['identifier'],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Returns types for SSR clients were incorrect ([gh issue](https://github.com/aws-amplify/amplify-category-api/issues/2643)), returning the **full** `Model` type from the schema, rather than the `Model['type']` property that matches the runtime result.

1. Added failing unit test coverage, demonstrating types mismatch with "normal" runtime client.
2. Fixed typings.
3. Observed passing tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
