### PR TITLE
fix: custom selection set return value for custom type arrays

### DIFF
--- a/.changeset/twelve-rockets-shout.md
+++ b/.changeset/twelve-rockets-shout.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/data-schema": patch
+---
+
+custom selection set return value for custom type array fields

--- a/packages/data-schema/src/runtime/client/index.ts
+++ b/packages/data-schema/src/runtime/client/index.ts
@@ -79,11 +79,15 @@ type ReturnValue<
  * This mapped type traverses the SelectionSetReturnValue result and the original FlatModel, restoring array types
  * that were flattened in DeepPickFromPath
  *
+ * Note: custom type field arrays are already handled correctly and don't need to be "restored", hence the `Result[K] extends Array<any>` check
+ *
  */
 type RestoreArrays<Result, FlatModel> = {
   [K in keyof Result]: K extends keyof FlatModel
     ? FlatModel[K] extends Array<any>
-      ? Array<RestoreArrays<Result[K], UnwrapArray<FlatModel[K]>>>
+      ? Result[K] extends Array<any>
+        ? Result[K]
+        : Array<RestoreArrays<Result[K], UnwrapArray<FlatModel[K]>>>
       : FlatModel[K] extends Record<string, any>
         ? RestoreArrays<Result[K], FlatModel[K]>
         : Result[K]

--- a/packages/integration-tests/__tests__/custom-selection-set.test-d.ts
+++ b/packages/integration-tests/__tests__/custom-selection-set.test-d.ts
@@ -447,9 +447,20 @@ describe('Custom Selection Set', () => {
         }),
       }),
 
+      Post6: a.model({
+        title: a.string().required(),
+        description: a.string(),
+        meta: a.ref('Meta').required(),
+      }),
+
       Location: a.customType({
         lat: a.float(),
         long: a.float(),
+      }),
+
+      Meta: a.customType({
+        tags: a.string().array(),
+        requiredTags: a.string().required().array().required(),
       }),
     });
 
@@ -535,6 +546,27 @@ describe('Custom Selection Set', () => {
       }[];
 
       type _ = Expect<Equal<typeof posts, ExpectedType>>;
+    });
+
+    // https://github.com/aws-amplify/amplify-category-api/issues/2368 - number 4.
+    test('custom selection set on explicit non-nullable custom type with array fields', async () => {
+      const selSet = ['title', 'meta.tags', 'meta.requiredTags'] as const;
+
+      const { data: posts } = await client.models.Post6.list({
+        selectionSet: selSet,
+      });
+
+      type ActualType = typeof posts;
+
+      type ExpectedType = {
+        readonly title: string;
+        readonly meta: {
+          readonly tags: (string | null)[] | null;
+          readonly requiredTags: string[];
+        };
+      }[];
+
+      type _ = Expect<Equal<ActualType, ExpectedType>>;
     });
   });
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes step 4. in https://github.com/aws-amplify/amplify-category-api/issues/2368
Other bugs mentioned in this issue have already been resolved in previous PRs

*Description of changes:*
Fixes bug where custom selection set return type on a required custom type array field was incorrectly showing up as a 2D array. (see [added integ test](https://github.com/aws-amplify/amplify-api-next/pull/257/files#diff-22e55aba2e0b5c58c5f7efb77760809432757ef7bd0c5cfd5abc91997785a68dR552) for an example of this)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
