### PR TITLE
ci: add E2E canary

### DIFF
--- a/.changeset/dull-games-juggle.md
+++ b/.changeset/dull-games-juggle.md
@@ -1,5 +1,0 @@
----
-"@aws-amplify/data-schema": patch
----
-
-update docs


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a canary that will run E2E tests at 7pm UTC (12pm PDT / 11am PST) every day.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
