### PR TITLE
fix: index query support with reqRes client

### DIFF
--- a/.changeset/slimy-horses-laugh.md
+++ b/.changeset/slimy-horses-laugh.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/data-schema": patch
+---
+
+fix index query support with reqRes client

--- a/packages/data-schema/src/runtime/internals/server/generateModelsProperty.ts
+++ b/packages/data-schema/src/runtime/internals/server/generateModelsProperty.ts
@@ -86,6 +86,7 @@ export function generateModelsProperty<T extends Record<any, any> = never>(
         model,
         idx,
         getInternals,
+        useContext,
       );
     }
   }

--- a/packages/integration-tests/__tests__/defined-behavior/3-exhaustive/ssr-req-res-client.ts
+++ b/packages/integration-tests/__tests__/defined-behavior/3-exhaustive/ssr-req-res-client.ts
@@ -1,0 +1,135 @@
+import { a, ClientSchema } from '@aws-amplify/data-schema';
+import { Amplify } from 'aws-amplify';
+import { buildAmplifyConfig, mockedGenerateClient } from '../../utils';
+
+/* eslint-disable import/no-extraneous-dependencies */
+import { GraphQLAPI } from '@aws-amplify/api-graphql';
+import { getAmplifyServerContext } from '@aws-amplify/core/internals/adapter-core';
+/* eslint-enable import/no-extraneous-dependencies */
+
+jest.mock('@aws-amplify/core/internals/adapter-core', () => ({
+  getAmplifyServerContext: jest.fn(),
+}));
+
+describe('something', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const schema = a
+    .schema({
+      StandaloneModel: a
+        .model({
+          name: a.string(),
+        })
+        .secondaryIndexes((index) => [index('name')]),
+      Parent: a.model({
+        name: a.string(),
+        children: a.hasMany('Child', 'parentId'),
+      }),
+      Child: a.model({
+        name: a.string(),
+        parentId: a.id(),
+        parent: a.belongsTo('Parent', 'parentId'),
+      }),
+    })
+    .authorization((allow) => [allow.publicApiKey()]);
+
+  type Schema = ClientSchema<typeof schema>;
+
+  test('happy path type and mocked runtime tests', async () => {
+    const { spy, generateServerClientUsingReqRes } = mockedGenerateClient([
+      {
+        data: {
+          getStandaloneModel: {
+            id: 'some-id',
+            name: 'something',
+          },
+        },
+      },
+      {
+        data: {
+          listStandaloneModel: [
+            {
+              id: 'some-id',
+              name: 'something',
+            },
+          ],
+        },
+      },
+      {
+        data: {
+          listStandaloneModelByName: [
+            {
+              id: 'some-id',
+              name: 'something',
+            },
+          ],
+        },
+      },
+    ]);
+
+    spy.mockImplementation(async (test) => {
+      return (GraphQLAPI as any)._graphql();
+    });
+
+    const config = await buildAmplifyConfig(schema);
+    Amplify.configure(config);
+
+    (getAmplifyServerContext as jest.Mock).mockImplementation(() => {
+      // the actual impl. of getAmplifyServerContext fetches the Amplify instance from a local registry
+      // based on the provided contextSpec (for SSR context isolation)
+      // we're mocking it to return the Amplify instance we just configured above
+      return { amplify: Amplify };
+    });
+
+    const client = generateServerClientUsingReqRes<Schema>({
+      config,
+    });
+
+    const mockContextSpec = { token: { value: Symbol('mock-token') } };
+
+    await client.models.StandaloneModel.get(mockContextSpec, {
+      id: 'something',
+    });
+
+    await client.models.StandaloneModel.list(mockContextSpec);
+
+    await client.models.StandaloneModel.listStandaloneModelByName(
+      mockContextSpec,
+      { name: 'bob' },
+    );
+
+    const calls = spy.mock.calls;
+
+    expect(calls[0]).toEqual([
+      Amplify,
+      expect.objectContaining({
+        query: expect.stringContaining('getStandaloneModel'),
+        variables: { id: 'something' },
+      }),
+      {},
+    ]);
+
+    expect(calls[1]).toEqual([
+      Amplify,
+      expect.objectContaining({
+        query: expect.stringContaining('listStandaloneModels'),
+      }),
+      {},
+    ]);
+
+    expect(calls[2]).toEqual([
+      Amplify,
+      expect.objectContaining({
+        query: expect.stringContaining('listStandaloneModelByName'),
+        variables: { name: 'bob' },
+      }),
+      {},
+    ]);
+  });
+});

--- a/packages/integration-tests/__tests__/utils/index.ts
+++ b/packages/integration-tests/__tests__/utils/index.ts
@@ -76,7 +76,7 @@ export async function buildAmplifyConfig(schema: {
  * Produces a `generateClient` function and associated spy that is pre-configured
  * to return the given list of responses in order.
  *
- * This helps facilitate a test structure where as much mocking as done ahead of
+ * This helps facilitate a test structure where as much mocking is done ahead of
  * time as possible, so that the test body can show "actual customer code" to the
  * greatest degree possible.
  *
@@ -132,7 +132,7 @@ export function mockedGenerateClient(
   function generateServerClientUsingReqRes<T extends Record<any, any>>(
     options: Parameters<typeof actualGenerateServerClientUsingReqRes>[0],
   ) {
-    return actualGenerateServerClientUsingReqRes(options);
+    return actualGenerateServerClientUsingReqRes<T>(options);
   }
 
   return {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-amplify/amplify-category-api/issues/2626

*Description of changes:*
Model-level Index query support for `generateServerClientUsingReqRes` was broken both at the type level and at runtime.
This PR resolves the issues and adds a basic integ tests validating the behavior.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
