### PR TITLE
ci: fix issue with local changes not being installed in E2E deps

### DIFF
--- a/packages/e2e-tests/node/package.json
+++ b/packages/e2e-tests/node/package.json
@@ -14,8 +14,8 @@
   "devDependencies": {
     "@aws-amplify/backend": "^1.0.4",
     "@aws-amplify/backend-cli": "^1.1.0",
-    "@aws-amplify/data-schema": "*",
-    "@aws-amplify/data-schema-types": "*",
+    "@aws-amplify/data-schema": "file:../../../node_modules/@aws-amplify/data-schema",
+    "@aws-amplify/data-schema-types": "file:../../../node_modules/@aws-amplify/data-schema-types",
     "@tsd/typescript": "^5.5.3",
     "@types/jest": "^29.5.12",
     "@types/node": "20.8.3",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Now that the E2E tests are located within a nested folder within the `e2e-tests` package (required, otherwise npx ampx sandbox can't find the executable), the sample is no longer correctly pulling local changes. This PR ensures that the tests are pulling from the local node modules, and not NPM.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
