### PR TITLE
feat: client tools and toolResult responses

### DIFF
--- a/packages/data-schema/src/ai/ConversationSchemaTypes.ts
+++ b/packages/data-schema/src/ai/ConversationSchemaTypes.ts
@@ -31,7 +31,7 @@ export const createConversationField = (
 
   const conversationDirective = `@conversation(${argsString}${toolsString})`;
 
-  return `${typeName}(conversationId: ID!, content: [ContentBlockInput], aiContext: AWSJSON): ConversationMessage ${conversationDirective} @aws_cognito_user_pools`;
+  return `${typeName}(conversationId: ID!, content: [ContentBlockInput], aiContext: AWSJSON, toolConfiguration: ToolConfigurationInput): ConversationMessage ${conversationDirective} @aws_cognito_user_pools`;
 };
 
 const isRef = (query: unknown): query is { data: InternalRef['data'] } =>
@@ -60,8 +60,8 @@ const ConversationMessage = `interface ConversationMessage {
   conversationId: ID!
   role: ConversationParticipantRole
   content: [ContentBlock]
-  context: AWSJSON
-  uiComponents: [AWSJSON]
+  aiContext: AWSJSON
+  toolConfiguration: ToolConfiguration
   createdAt: AWSDateTime
   updatedAt: AWSDateTime
   owner: String
@@ -118,6 +118,12 @@ const ImageBlockSource = `type ImageBlockSource {
   bytes: String
 }`;
 
+const ToolUseBlockInput = `input ToolUseBlockInput {
+  toolUseId: String!
+  name: String!
+  input: AWSJSON!
+}`;
+
 const ToolUseBlock = `type ToolUseBlock {
   toolUseId: String!
   name: String!
@@ -162,6 +168,7 @@ const ContentBlockInput = `input ContentBlockInput {
   document: DocumentBlockInput
   image: ImageBlockInput
   toolResult: ToolResultBlockInput
+  toolUse: ToolUseBlockInput
 }`;
 
 const ContentBlock = `type ContentBlock {
@@ -172,6 +179,43 @@ const ContentBlock = `type ContentBlock {
   toolUse: ToolUseBlock
 }`;
 
+const ToolConfigurationInput = `input ToolConfigurationInput {
+  tools: [ToolInput]
+}`;
+
+const ToolInput = `input ToolInput {
+  toolSpec: ToolSpecificationInput
+}`;
+
+const ToolSpecificationInput = `input ToolSpecificationInput {
+  name: String!
+  description: String
+  inputSchema: ToolInputSchemaInput!
+}`;
+
+const ToolInputSchemaInput = `input ToolInputSchemaInput {
+  json: AWSJSON
+}`;
+
+const ToolConfiguration = `type ToolConfiguration {
+  tools: [Tool]
+}`;
+
+const Tool = `type Tool {
+  toolSpec: ToolSpecification
+}`;
+
+const ToolSpecification = `type ToolSpecification {
+  name: String!
+  description: String
+  inputSchema: ToolInputSchema!
+}`;
+
+const ToolInputSchema = `type ToolInputSchema {
+  json: AWSJSON
+}`;
+
+
 export const conversationTypes: string[] = [
   ConversationParticipantRole,
   ConversationMessage,
@@ -179,6 +223,7 @@ export const conversationTypes: string[] = [
   DocumentBlockInput,
   ImageBlockSourceInput,
   ImageBlockInput,
+  ToolUseBlockInput,
   ToolResultContentBlockInput,
   ToolResultBlockInput,
   DocumentBlockSource,
@@ -195,4 +240,12 @@ export const conversationTypes: string[] = [
   ContentBlockToolResult,
   ContentBlockInput,
   ContentBlock,
+  ToolConfigurationInput,
+  ToolInput,
+  ToolSpecificationInput,
+  ToolInputSchemaInput,
+  ToolConfiguration,
+  Tool,
+  ToolSpecification,
+  ToolInputSchema,
 ];

--- a/packages/data-schema/src/ai/types/ToolConfiguration.ts
+++ b/packages/data-schema/src/ai/types/ToolConfiguration.ts
@@ -7,7 +7,7 @@ interface ToolJsonInputSchema {
   json: DocumentType;
 }
 
-interface ToolSpecification {
+export interface ToolSpecification {
   name: string;
   inputSchema: ToolJsonInputSchema;
   description?: string;

--- a/packages/data-schema/src/runtime/internals/ai/createSendMessageFunction.ts
+++ b/packages/data-schema/src/runtime/internals/ai/createSendMessageFunction.ts
@@ -13,6 +13,7 @@ import type {
 } from '../../bridge-types';
 import { customOpFactory } from '../operations/custom';
 import { pickConversationMessageProperties } from './pickConversationMessageProperties';
+import { Tool, ToolSpecification } from '../../../ai/types/ToolConfiguration';
 
 export const createSendMessageFunction =
   (
@@ -24,6 +25,10 @@ export const createSendMessageFunction =
   ): Conversation['sendMessage'] =>
   async ({ aiContext, content, toolConfiguration }) => {
     const { conversations } = modelIntrospection;
+
+    const tools: { toolSpec: ToolSpecification }[] = toolConfiguration?.tools
+      ? Object.entries(toolConfiguration.tools).map(convertToolForGql)
+      : [];
     // Safe guard for standalone function. When called as part of client generation, this should never be falsy.
     if (!conversations) {
       return {} as SingularReturnValue<ConversationMessage>;
@@ -43,10 +48,23 @@ export const createSendMessageFunction =
       aiContext: JSON.stringify(aiContext),
       content,
       conversationId,
-      toolConfiguration,
+      toolConfiguration: { tools },
     });
     return {
       data: data ? pickConversationMessageProperties(data) : data,
       errors,
     };
   };
+
+  function convertToolForGql(value: [string, Tool]) {
+    const [name, tool] = value;
+    return {
+      toolSpec: {
+        name,
+        description: tool.description,
+        inputSchema: {
+          json: JSON.stringify(tool.inputSchema?.json)
+        }
+      }
+    };
+  }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Adds `toolConfiguration: ToolConfiguration` to `ConversationMessage` interface.
- Adds tool use and tool definition GraphQL types.
- Converts `Record<string, Omit<ToolSpecification, 'name'>` (data client API representation) to `ToolSpecification[]` (GraphQL representation). This client / AppSync type discrepancy is desired to prevent duplicate name definitions among tools, while maintaining a typed structure (not just AWSJSON) in the GraphQL schema. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
