### PR TITLE
chore: Enforce valid JSON schema for tool config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6750,7 +6750,8 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -16979,6 +16980,7 @@
         "@rollup/plugin-typescript": "11.1.5",
         "@tsd/typescript": "^5.1.6",
         "@types/jest": "29.5.4",
+        "@types/json-schema": "^7.0.15",
         "jest": "^29.7.0",
         "jest-tsd": "^0.2.2",
         "rimraf": "^5.0.5",

--- a/packages/data-schema/__tests__/internals/ai/conversationMessageSerializers.test.ts
+++ b/packages/data-schema/__tests__/internals/ai/conversationMessageSerializers.test.ts
@@ -39,16 +39,30 @@ describe('conversationMessageSerializers', () => {
   const mockTimeTool = {
     description: 'Get current time',
     inputSchema: {
-      json: { properties: { timeZone: 'string' } },
+      json: {
+        type: 'object',
+        properties: {
+          timeZone: {
+            type: 'string',
+          },
+        },
+      },
     },
-  };
+  } as const;
   const mockWeatherToolName = 'currentWeather';
   const mockWeatherTool = {
     description: 'Get current weather',
     inputSchema: {
-      json: { properties: { location: 'Seattle, WA' } },
+      json: {
+        type: 'object',
+        properties: {
+          location: {
+            type: 'string',
+          },
+        },
+      },
     },
-  };
+  } as const;
   const mockToolConfiguration = {
     tools: {
       [mockTimeToolName]: mockTimeTool,

--- a/packages/data-schema/__tests__/internals/ai/createSendMessageFunction.test.ts
+++ b/packages/data-schema/__tests__/internals/ai/createSendMessageFunction.test.ts
@@ -27,11 +27,18 @@ describe('createSendMessageFunction()', () => {
     tools: {
       [mockToolName]: {
         inputSchema: {
-          json: {},
+          json: {
+            type: 'object',
+            properties: {
+              foo: {
+                type: 'string',
+              },
+            },
+          },
         },
       },
     },
-  };
+  } as const;
   const mockSerializedToolConfiguration = {
     tools: [
       {

--- a/packages/data-schema/package.json
+++ b/packages/data-schema/package.json
@@ -60,6 +60,7 @@
     "@rollup/plugin-typescript": "11.1.5",
     "@tsd/typescript": "^5.1.6",
     "@types/jest": "29.5.4",
+    "@types/json-schema": "^7.0.15",
     "jest": "^29.7.0",
     "jest-tsd": "^0.2.2",
     "rimraf": "^5.0.5",

--- a/packages/data-schema/src/ai/types/ToolConfiguration.ts
+++ b/packages/data-schema/src/ai/types/ToolConfiguration.ts
@@ -1,10 +1,17 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import type { DocumentType } from '../../runtime/bridge-types';
+import type { JSONSchema4 } from 'json-schema';
+
+interface ObjectTypedJSONSchema4 extends JSONSchema4 {
+  type: 'object';
+}
 
 interface ToolJsonInputSchema {
-  json: DocumentType;
+  /**
+   * The schema for the tool. The top level schema type must be object.
+   */
+  json: ObjectTypedJSONSchema4;
 }
 
 export interface Tool {


### PR DESCRIPTION
*Description of changes:*
This PR updates the ToolConfiguration json schema to actually require JSON schema instead of just arbitrary `DocumentType`. Ultimately, the AI model will expect valid JSON schema (with type of object at top level) in order to select a tool.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
