### PR TITLE
chore: move JSON Schema type into dependency

### DIFF
--- a/packages/data-schema/package.json
+++ b/packages/data-schema/package.json
@@ -53,6 +53,7 @@
     "@aws-amplify/data-schema-types": "*",
     "@smithy/util-base64": "^3.0.0",
     "@types/aws-lambda": "^8.10.134",
+    "@types/json-schema": "^7.0.15",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
@@ -60,7 +61,6 @@
     "@rollup/plugin-typescript": "11.1.5",
     "@tsd/typescript": "^5.1.6",
     "@types/jest": "29.5.4",
-    "@types/json-schema": "^7.0.15",
     "jest": "^29.7.0",
     "jest-tsd": "^0.2.2",
     "rimraf": "^5.0.5",


### PR DESCRIPTION
*Description of changes:*
This PR moves `@types/json-schema` from the `devDependency` block of the `@aws-amplify/data-schema` package into the `dependency` block. Since this type is used to derive type information for a properly defined JSON schema, it needs to transitively carry over into projects consuming this package.

This was verified to work by:
1. Publishing the package as is to a local verdaccio registry
2. Confirming the `toolConfiguration` property displays type errors with properly formatted JSON schema input
3. Moving `@types/json-schema` into dependencies
4. Confirming the `toolConfiguration` property no longer displays type errors with properly formatted JSON schema input

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
