### PR TITLE
chore: Expose conversation types through schema

### DIFF
--- a/packages/data-schema/src/ClientSchema/ai/ClientConversation.ts
+++ b/packages/data-schema/src/ClientSchema/ai/ClientConversation.ts
@@ -1,9 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { ClientSchemaProperty } from '../Core';
+import type {
+  Conversation,
+  ConversationMessage,
+} from '../../ai/ConversationType';
+import type { ClientSchemaProperty } from '../Core';
 
 export interface ClientConversation
   extends Pick<ClientSchemaProperty, '__entityType'> {
   __entityType: 'customConversation';
+  type: Conversation;
+  messageType: ConversationMessage;
 }


### PR DESCRIPTION
*Description of changes:*
This PR exposes the `Conversation` and `ConversationMessage` types via ClientSchema. With this PR, it is now possible to obtain these types via:
```ts
type PirateConversation = Schema['pirateChat']['type'];
type PirateConversationMessage = Schema['pirateChat']['messageType'];
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
