### PR TITLE
fix: Hide forwarded input from exposed conversation type

### DIFF
--- a/packages/data-schema/src/SchemaProcessor.ts
+++ b/packages/data-schema/src/SchemaProcessor.ts
@@ -1,8 +1,4 @@
-import type {
-  ConversationType,
-  CustomPathData,
-  InternalSchema,
-} from './ModelSchema';
+import type { CustomPathData, InternalSchema } from './ModelSchema';
 import {
   type ModelField,
   type InternalField,
@@ -50,7 +46,10 @@ import {
 } from './Handler';
 import * as os from 'os';
 import * as path from 'path';
-import { brandName as conversationBrandName } from './ai/ConversationType';
+import {
+  brandName as conversationBrandName,
+  type InternalConversationType,
+} from './ai/ConversationType';
 import {
   conversationTypes,
   createConversationField,
@@ -98,7 +97,7 @@ function isCustomType(
   return false;
 }
 
-function isConversationRoute(type: any): type is ConversationType {
+function isConversationRoute(type: any): type is InternalConversationType {
   return getBrand(type) === conversationBrandName;
 }
 
@@ -499,14 +498,18 @@ function customOperationToGql(
         `Invalid Generation Route definition. A Generation Route must include a valid input. ${typeName} has an invalid or no input defined.`,
       );
     }
-    const { aiModel, systemPrompt, inferenceConfiguration } = typeDef.data.input;
+    const { aiModel, systemPrompt, inferenceConfiguration } =
+      typeDef.data.input;
 
-    const inferenceConfigurationEntries = Object.entries(inferenceConfiguration ?? {});
-    const inferenceConfigurationGql = inferenceConfigurationEntries.length > 0
-      ? `, inferenceConfiguration: { ${inferenceConfigurationEntries
-        .map(([key, value]) => `${key}: ${value}`)
-        .join(', ')} }`
-      : '';
+    const inferenceConfigurationEntries = Object.entries(
+      inferenceConfiguration ?? {},
+    );
+    const inferenceConfigurationGql =
+      inferenceConfigurationEntries.length > 0
+        ? `, inferenceConfiguration: { ${inferenceConfigurationEntries
+            .map(([key, value]) => `${key}: ${value}`)
+            .join(', ')} }`
+        : '';
     gqlHandlerContent += `@generation(aiModel: "${aiModel.resourcePath}", systemPrompt: "${systemPrompt}"${inferenceConfigurationGql}) `;
   }
 

--- a/packages/data-schema/src/ai/ConversationSchemaTypes.ts
+++ b/packages/data-schema/src/ai/ConversationSchemaTypes.ts
@@ -1,9 +1,12 @@
 import { InternalRef } from '../RefType';
 import { capitalize } from '../runtime/utils';
-import type { ConversationType, ToolDefinition } from './ConversationType';
+import type {
+  InternalConversationType,
+  ToolDefinition,
+} from './ConversationType';
 
 export const createConversationField = (
-  typeDef: ConversationType,
+  typeDef: InternalConversationType,
   typeName: string,
 ): string => {
   const { aiModel, systemPrompt, handler, tools } = typeDef;
@@ -214,7 +217,6 @@ const ToolSpecification = `type ToolSpecification {
 const ToolInputSchema = `type ToolInputSchema {
   json: AWSJSON
 }`;
-
 
 export const conversationTypes: string[] = [
   ConversationParticipantRole,

--- a/packages/data-schema/src/ai/ConversationType.ts
+++ b/packages/data-schema/src/ai/ConversationType.ts
@@ -109,9 +109,11 @@ export interface ConversationInput {
   handler?: DefineFunction | string;
 }
 
-export interface ConversationType
-  extends Brand<typeof brandName>,
+export interface InternalConversationType
+  extends ConversationType,
     ConversationInput {}
+
+export interface ConversationType extends Brand<typeof brandName> {}
 
 function _conversation(input: ConversationInput): ConversationType {
   return { ...brand(brandName), ...input };


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds an intermediary internal type to obfuscate conversation route inputs from the conversation route chaining.

Before:
<img width="487" alt="image" src="https://github.com/user-attachments/assets/fde6d0d1-91c1-4442-b837-335ae812d642">

After:
<img width="319" alt="image" src="https://github.com/user-attachments/assets/963ef66b-916a-49d4-96ad-f7ce8d40e850">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
