### PR TITLE
fix: timestamps in model props breaks runtime

### DIFF
--- a/.changeset/olive-rules-shout.md
+++ b/.changeset/olive-rules-shout.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/data-schema": patch
+---
+
+fix: timestamps in model props breaks runtime

--- a/packages/data-schema/src/runtime/internals/clientUtils.ts
+++ b/packages/data-schema/src/runtime/internals/clientUtils.ts
@@ -49,6 +49,7 @@ export const excludeDisabledOps = (
     "properties": {
       "subscriptions": null,
       "mutations": { "delete": null }
+      "timestamps": null
     } }*/
   const modelAttrs = mis.models[modelName].attributes?.find(
     (attr) => attr.type === 'model',
@@ -68,6 +69,11 @@ export const excludeDisabledOps = (
 
   if (modelAttrs.properties) {
     for (const [key, value] of Object.entries(modelAttrs.properties)) {
+      // model.properties can contain other values that are not relevant to disabling ops, e.g. timestamps
+      if (!(key in coarseToFineDict)) {
+        continue;
+      }
+
       if (value === null) {
         // coarse-grained disable, e.g. "subscriptions": null,
         disabledOps.push(...coarseToFineDict[key]);

--- a/packages/integration-tests/__tests__/defined-behavior/2-expected-use/disable-operations.ts
+++ b/packages/integration-tests/__tests__/defined-behavior/2-expected-use/disable-operations.ts
@@ -217,4 +217,32 @@ describe('disable model operations', () => {
       cm!.comment();
     }).toThrowError('cm.comment is not a function');
   });
+
+  test('does not break if `timestamps` present in model properties', async () => {
+    const { generateClient } = mockedGenerateClient([
+      {
+        data: {
+          listPosts: {
+            __typeName: 'FineGrained',
+            id: 'a1',
+            data: '',
+            updatedAt: '2024-08-07T19:05:44.536Z',
+            createdAt: '2024-09-07T18:05:44.536Z',
+          },
+        },
+      },
+    ]);
+    const config = await buildAmplifyConfig(schema);
+
+    // Manually injecting `timestamps` because this config is not exposed via Gen2
+    config.modelIntrospection.models.Post.attributes[0].properties = {
+      ...config.modelIntrospection.models.Post.attributes[0].properties,
+      timestamps: null,
+    };
+
+    Amplify.configure(config);
+    const client = generateClient<Schema>();
+
+    await client.models.Post.list();
+  });
 });


### PR DESCRIPTION
Issue reported by internal customer.

*Description of changes:*
The ability to disable model timestamp fields is not exposed via Gen2, however, Gen1 customers who use this feature are currently getting a runtime error with recent versions of data-schema.

Fix was TDD'd and also manually validated with the customer's amplify_outputs file

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
