### PR TITLE
fix(ai): make stream part - contentBlockIndex optional

### DIFF
--- a/.changeset/many-dots-invite.md
+++ b/.changeset/many-dots-invite.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/data-schema": patch
+---
+
+make ConversationMessageStreamPart.contentBlockIndex optional for error events

--- a/packages/data-schema/__tests__/__snapshots__/ClientSchema.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/ClientSchema.test.ts.snap
@@ -214,7 +214,7 @@ type ConversationMessageStreamPart @aws_cognito_user_pools {
   owner: String
   conversationId: ID!
   associatedUserMessageId: ID!
-  contentBlockIndex: Int!
+  contentBlockIndex: Int
   contentBlockText: String
   contentBlockDeltaIndex: Int
   contentBlockToolUse: ToolUseBlock

--- a/packages/data-schema/src/ai/ConversationSchemaTypes.ts
+++ b/packages/data-schema/src/ai/ConversationSchemaTypes.ts
@@ -235,7 +235,7 @@ const ConversationMessageStreamEvent = `type ConversationMessageStreamPart @aws_
   owner: String
   conversationId: ID!
   associatedUserMessageId: ID!
-  contentBlockIndex: Int!
+  contentBlockIndex: Int
   contentBlockText: String
   contentBlockDeltaIndex: Int
   contentBlockToolUse: ToolUseBlock

--- a/packages/integration-tests/__tests__/defined-behavior/2-expected-use/__snapshots__/ai-conversation.ts.snap
+++ b/packages/integration-tests/__tests__/defined-behavior/2-expected-use/__snapshots__/ai-conversation.ts.snap
@@ -562,7 +562,7 @@ type ConversationMessageStreamPart @aws_cognito_user_pools {
   owner: String
   conversationId: ID!
   associatedUserMessageId: ID!
-  contentBlockIndex: Int!
+  contentBlockIndex: Int
   contentBlockText: String
   contentBlockDeltaIndex: Int
   contentBlockToolUse: ToolUseBlock


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
- Makes `ConversationMessageStreamPart.contentBlockIndex` in GraphQL supporting types optional. This was missed in https://github.com/aws-amplify/amplify-api-next/pull/385.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
