### PR TITLE
chore: add claude models 3.5 haiku and 3.5 sonnet v2

### DIFF
--- a/.changeset/tricky-cameras-share.md
+++ b/.changeset/tricky-cameras-share.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/data-schema": patch
+---
+
+Add Claude 3.5 Haiku and 3.5 Sonnet v2 models

--- a/packages/data-schema/src/ai/ModelType.ts
+++ b/packages/data-schema/src/ai/ModelType.ts
@@ -8,7 +8,9 @@ const supportedModelsLookup = {
   'Claude 3 Haiku': 'anthropic.claude-3-haiku-20240307-v1:0',
   'Claude 3 Opus': 'anthropic.claude-3-opus-20240229-v1:0',
   'Claude 3 Sonnet': 'anthropic.claude-3-sonnet-20240229-v1:0',
+  'Claude 3.5 Haiku': 'anthropic.claude-3-5-haiku-20241022-v1:0',
   'Claude 3.5 Sonnet': 'anthropic.claude-3-5-sonnet-20240620-v1:0',
+  'Claude 3.5 Sonnet v2': 'anthropic.claude-3-5-sonnet-20241022-v2:0',
   // Cohere models
   'Cohere Command R': 'cohere.command-r-v1:0',
   'Cohere Command R+': 'cohere.command-r-plus-v1:0',


### PR DESCRIPTION
## Problem
The `AiModel` supported models don't include the recently added Claude 3.5 Haiku or Claude 3.5 Sonnet v2 models.

**Issue number, if available:**
N/A

## Changes
Adds Claude 3.5 Haiku and Claude 3.5 Sonnet v2 models to the supported models for conversation and generated routes.

Bedrock documentation reference: https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html

**Corresponding docs PR, if applicable:**
N/A

## Validation
![image](https://github.com/user-attachments/assets/7aa79288-138d-4bef-b9f4-70133751579a)

## Checklist

- [ ] ~If this PR includes a functional change to the runtime or type-level behavior of the code, I have added or updated automated test coverage for this change. (see [Testing Strategy README](../TESTING-STRATEGY.md))~
- [ ] ~If this PR requires a docs update, I have linked to that docs PR above.~

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
