### PR TITLE
fix: DeepPickFromPath<> to flatten Arrays of Models referenced in a join table

### DIFF
--- a/.changeset/slow-paws-own.md
+++ b/.changeset/slow-paws-own.md
@@ -1,0 +1,6 @@
+---
+'integration-tests': patch
+'@aws-amplify/data-schema': patch
+---
+
+Fix DeepPickFromPath unable to flatten arrays in a join table

--- a/packages/data-schema/src/runtime/client/index.ts
+++ b/packages/data-schema/src/runtime/client/index.ts
@@ -198,15 +198,25 @@ type DeepPickFromPath<
         ? Head extends keyof FlatModel
           ? Tail extends '*'
             ? {
-                [k in Head]: NonRelationshipFields<
-                  UnwrapArray<FlatModel[Head]>
-                >;
+                [k in Head]: FlatModel[Head] extends Record<string, unknown>
+                  ? NonRelationshipFields<FlattenArrays<FlatModel[Head]>>
+                  : NonRelationshipFields<UnwrapArray<FlatModel[Head]>>;
               }
             : { [k in Head]: DeepPickFromPath<FlatModel[Head], Tail> }
           : never
         : Path extends keyof FlatModel
           ? { [K in Path]: FlatModel[Path] }
           : never;
+
+/**
+ * This mapped type gets called by DeepPickFromPath<FlatModel, Path> when user uses selection
+ * set on a query to a many-to-many relationship join table. It flattens the Arrays of Models referenced in the join table.
+ *
+ * (e.g. { customer: { orders: Order[]} } => { customer: { orders: Order} })
+ */
+type FlattenArrays<T> = {
+  [K in keyof T]: UnwrapArray<T[K]>;
+};
 
 /**
  * Generates custom selection set type with up to 6 levels of nested fields

--- a/packages/integration-tests/__tests__/defined-behavior/3-exhaustive/custom-selection-set.ts
+++ b/packages/integration-tests/__tests__/defined-behavior/3-exhaustive/custom-selection-set.ts
@@ -7,8 +7,6 @@ import {
 } from '../../utils';
 import { Expect, Equal, Prettify } from '@aws-amplify/data-schema-types';
 import { SelectionSet } from 'aws-amplify/data';
-import { optionsAndHeaders } from '../../utils';
-import { ResolveSchema } from '../../../../data-schema/dist/esm/MappedTypes/ResolveSchema';
 
 describe('Custom selection set edge cases', () => {
   afterEach(() => {
@@ -1218,14 +1216,12 @@ describe('Custom selection set edge cases', () => {
           //sth is wrong here
           selectionSet: [
             'customer.*',
-            // 'customer.verbiageReqReq.*',
-            // 'customer.verbiageOptReq.*',
-            // 'customer.verbiageReqOpt.*',
-            // 'customer.verbiageOptOpt.*',
+            'customer.verbiageReqReq.*',
+            'customer.verbiageOptReq.*',
+            'customer.verbiageReqOpt.*',
+            'customer.verbiageOptOpt.*',
           ],
         });
-        console.log(optionsAndHeaders(spy)[0][0].query);
-
         return { data, spy };
       }
 
@@ -1265,11 +1261,6 @@ describe('Custom selection set edge cases', () => {
         type ActualType = typeof cus;
         type _test = Expect<Equal<ActualType, ExpectedType>>;
       });
-
-      // const verbiageReqReq = cps.verbiageReqReq; // should be Verbiage[] and it is!
-      // const verbiageOptReq = cps.verbiageOptReq; // should be (Verbiage | null)[], but is (never[] | null)[]
-      // const verbiageReqOpt = cps.verbiageReqOpt; // should be Verbiage[] | null, but is never[][] | null
-      // const verbiageOptOpt = cps.verbiageOptOpt; // should be (Verbiage | null)[] | null, but is (never[] | null)[] | null
     });
   });
 });

--- a/packages/integration-tests/__tests__/defined-behavior/3-exhaustive/custom-selection-set.ts
+++ b/packages/integration-tests/__tests__/defined-behavior/3-exhaustive/custom-selection-set.ts
@@ -5,7 +5,7 @@ import {
   mockedGenerateClient,
   expectSelectionSetEquals,
 } from '../../utils';
-import { Expect, Equal, Prettify } from '@aws-amplify/data-schema-types';
+import { Expect, Equal } from '@aws-amplify/data-schema-types';
 import { SelectionSet } from 'aws-amplify/data';
 
 describe('Custom selection set edge cases', () => {

--- a/packages/integration-tests/__tests__/defined-behavior/3-exhaustive/custom-selection-set.ts
+++ b/packages/integration-tests/__tests__/defined-behavior/3-exhaustive/custom-selection-set.ts
@@ -1006,7 +1006,7 @@ describe('Custom selection set edge cases', () => {
         }[];
 
         type ActualType = typeof data;
-        type p = Prettify<ActualType>;
+
         type _test = Expect<Equal<ActualType, ExpectedTodoType>>;
       });
     });

--- a/packages/integration-tests/__tests__/defined-behavior/3-exhaustive/custom-selection-set.ts
+++ b/packages/integration-tests/__tests__/defined-behavior/3-exhaustive/custom-selection-set.ts
@@ -5,8 +5,10 @@ import {
   mockedGenerateClient,
   expectSelectionSetEquals,
 } from '../../utils';
-import { Expect, Equal } from '@aws-amplify/data-schema-types';
+import { Expect, Equal, Prettify } from '@aws-amplify/data-schema-types';
 import { SelectionSet } from 'aws-amplify/data';
+import { optionsAndHeaders } from '../../utils';
+import { ResolveSchema } from '../../../../data-schema/dist/esm/MappedTypes/ResolveSchema';
 
 describe('Custom selection set edge cases', () => {
   afterEach(() => {
@@ -1006,7 +1008,7 @@ describe('Custom selection set edge cases', () => {
         }[];
 
         type ActualType = typeof data;
-
+        type p = Prettify<ActualType>;
         type _test = Expect<Equal<ActualType, ExpectedTodoType>>;
       });
     });
@@ -1105,6 +1107,169 @@ describe('Custom selection set edge cases', () => {
       type ActualType = typeof data;
 
       type _test = Expect<Equal<ActualType, ExpectedTodoType>>;
+    });
+  });
+
+  describe('optional array with many-to-many relationships', () => {
+    const schema = a
+      .schema({
+        AlphabetEnum: a.enum(['A', 'B', 'C', 'D']),
+        Customer: a.model({
+          name: a.string().required(),
+          verbiageReqReq: a.ref('Verbiage').required().array().required(),
+          verbiageOptReq: a.ref('Verbiage').array().required(),
+          verbiageReqOpt: a.ref('Verbiage').required().array(),
+          verbiageOptOpt: a.ref('Verbiage').array(),
+          orders: a.hasMany('CustomerPart', 'customerId'),
+        }),
+        Verbiage: a.customType({
+          name: a.ref('AlphabetEnum').required(),
+          paragraphs: a.string().required().array().required(),
+        }),
+        CustomerPart: a.model({
+          customer: a.belongsTo('Customer', 'customerId'),
+          customerId: a.string(),
+          experience: a.string(),
+          part: a.belongsTo('Part', 'partId'),
+          partId: a.string(),
+        }),
+        Part: a.model({
+          name: a.string().required(),
+          orders: a.hasMany('CustomerPart', 'partId'),
+        }),
+      })
+      .authorization((allow) => allow.guest());
+
+    type Schema = ClientSchema<typeof schema>;
+
+    async function getMockedClient(
+      operationName: string,
+      mockedResult: object,
+    ) {
+      const { spy, generateClient } = mockedGenerateClient([
+        {
+          data: {
+            [operationName]: {
+              items: [mockedResult],
+            },
+          },
+        },
+      ]);
+
+      const config = await buildAmplifyConfig(schema);
+      Amplify.configure(config);
+      const client = generateClient<Schema>();
+      return { client, spy };
+    }
+
+    describe('Defined many-to-many relations', () => {
+      const sampleCustomerPart = {
+        customer: [
+          {
+            name: 'some-customer',
+            verbiageReqReq: [
+              {
+                name: 'A',
+                paragraphs: ['some-paragraph'],
+              },
+            ],
+            verbiageOptReq: [
+              {
+                name: 'A',
+                paragraphs: ['some-paragraph'],
+              },
+            ],
+            verbiageReqOpt: [
+              {
+                name: 'A',
+                paragraphs: ['some-paragraph'],
+              },
+            ],
+            verbiageOptOpt: [
+              {
+                name: 'A',
+                paragraphs: ['some-paragraph'],
+              },
+            ],
+          },
+        ],
+        customerId: 'some-customer-id',
+        part: [
+          {
+            name: 'some-part',
+            orders: [
+              {
+                customerId: 'some-customer-id',
+                partId: 'some-part-id',
+              },
+            ],
+          },
+        ],
+        partId: 'some-part-id',
+      };
+
+      async function mockedOperation() {
+        const { client, spy } = await getMockedClient(
+          'listCustomerPart',
+          sampleCustomerPart,
+        );
+
+        const { data } = await client.models.CustomerPart.list({
+          //sth is wrong here
+          selectionSet: [
+            'customer.*',
+            // 'customer.verbiageReqReq.*',
+            // 'customer.verbiageOptReq.*',
+            // 'customer.verbiageReqOpt.*',
+            // 'customer.verbiageOptOpt.*',
+          ],
+        });
+        console.log(optionsAndHeaders(spy)[0][0].query);
+
+        return { data, spy };
+      }
+
+      type Verbiage = {
+        readonly name: 'A' | 'B' | 'C' | 'D';
+        readonly paragraphs: string[];
+      };
+
+      test('.required().array().required()', async () => {
+        const { data } = await mockedOperation();
+        const cus = data[0].customer.verbiageReqReq;
+        type ExpectedType = Verbiage[];
+        type ActualType = typeof cus;
+        type _test = Expect<Equal<ActualType, ExpectedType>>;
+      });
+
+      test('.array().required()', async () => {
+        const { data } = await mockedOperation();
+        const cus = data[0].customer.verbiageOptReq;
+        type ExpectedType = (Verbiage | null)[];
+        type ActualType = typeof cus;
+        type _test = Expect<Equal<ActualType, ExpectedType>>;
+      });
+
+      test('.required().array()', async () => {
+        const { data } = await mockedOperation();
+        const cus = data[0].customer.verbiageReqOpt;
+        type ExpectedType = Verbiage[] | null;
+        type ActualType = typeof cus;
+        type _test = Expect<Equal<ActualType, ExpectedType>>;
+      });
+
+      test('.array()', async () => {
+        const { data } = await mockedOperation();
+        const cus = data[0].customer.verbiageOptOpt;
+        type ExpectedType = (Verbiage | null)[] | null;
+        type ActualType = typeof cus;
+        type _test = Expect<Equal<ActualType, ExpectedType>>;
+      });
+
+      // const verbiageReqReq = cps.verbiageReqReq; // should be Verbiage[] and it is!
+      // const verbiageOptReq = cps.verbiageOptReq; // should be (Verbiage | null)[], but is (never[] | null)[]
+      // const verbiageReqOpt = cps.verbiageReqOpt; // should be Verbiage[] | null, but is never[][] | null
+      // const verbiageOptOpt = cps.verbiageOptOpt; // should be (Verbiage | null)[] | null, but is (never[] | null)[] | null
     });
   });
 });

--- a/packages/integration-tests/__tests__/defined-behavior/3-exhaustive/custom-selection-set.ts
+++ b/packages/integration-tests/__tests__/defined-behavior/3-exhaustive/custom-selection-set.ts
@@ -1213,7 +1213,6 @@ describe('Custom selection set edge cases', () => {
         );
 
         const { data } = await client.models.CustomerPart.list({
-          //sth is wrong here
           selectionSet: [
             'customer.*',
             'customer.verbiageReqReq.*',


### PR DESCRIPTION
*Related issues:*
- https://github.com/aws-amplify/amplify-category-api/issues/3062

*Description of changes:*

This change adds a defined-behavior integration test for custom selection set. The test creates a model that serves as "join table" with two one-to-many relationships between two entities. The test then uses a query on the "join table" model with a custom selection set to get one of the entities. It will fail since that entity has an array field, and `DeepPickFromPath()` is unable to flatten that array, which causes errors in type intersections.

The change then fixes the bug by adding a check in `DeepPickFromPath()` for custom type in a model's fields. If the field is a custom type, the function will flatten the array fields inside that data model as well. 

*Example of why we need this:*

If customers have two data models `Part` and `Customer`, and a model `CustomerPart` that serves as a "join table":

```ts
Customer: a.model({
          name: a.string().required(),
          verbiageReqReq: a.ref('Verbiage').required().array().required(),
          verbiageOptReq: a.ref('Verbiage').array().required(),
          verbiageReqOpt: a.ref('Verbiage').required().array(),
          verbiageOptOpt: a.ref('Verbiage').array(),
          orders: a.hasMany('CustomerPart', 'customerId'),
        }),
CustomerPart: a.model({
          customer: a.belongsTo('Customer', 'customerId'),
          customerId: a.string(),
          experience: a.string(),
          part: a.belongsTo('Part', 'partId'),
          partId: a.string(),
        }),
Part: a.model({
          name: a.string().required(),
          orders: a.hasMany('CustomerPart', 'partId'),
        }),
```
when they try to query the customer's data from `CustomerPart` using a selection set:
```ts
const { data } = await client.models.CustomerPart.list({
          selectionSet: [
            'customer.*',
            'customer.verbiageReqReq.*',
            'customer.verbiageOptReq.*',
            'customer.verbiageReqOpt.*',
            'customer.verbiageOptOpt.*',
          ],
        });
```
they will get wrong types in their results:
```ts
const cps = data[0].customer;
        const verbiageReqReq = cps.verbiageReqReq; // should be Verbiage[] and it is
        const verbiageOptReq = cps.verbiageOptReq; // should be (Verbiage | null)[], but is (never[] | null)[]
        const verbiageReqOpt = cps.verbiageReqOpt; // should be Verbiage[] | null, but is never[][] | null
        const verbiageOptOpt = cps.verbiageOptOpt; // should be (Verbiage | null)[] | null, but is (never[] | null)[] | null
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



