### PR TITLE
Add JSDoc and flatten param types for data schema builder methods

### DIFF
--- a/.changeset/quick-birds-hug.md
+++ b/.changeset/quick-birds-hug.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/data-schema': patch
+---
+
+Add JSDoc for Data schema builder methods

--- a/packages/data-schema/docs/data-schema.modeltype.md
+++ b/packages/data-schema/docs/data-schema.modeltype.md
@@ -14,8 +14,8 @@ export type ModelType<T extends ModelTypeParamShape = ModelTypeParamShape, UsedM
     identifier<PrimaryIndexFields = ExtractSecondaryIndexIRFields<T>, PrimaryIndexPool extends string = keyof PrimaryIndexFields & string, const ID extends ReadonlyArray<PrimaryIndexPool> = readonly [], const PrimaryIndexIR extends PrimaryIndexIrShape = PrimaryIndexFieldsToIR<ID, PrimaryIndexFields>>(identifier: ID): ModelType<SetTypeSubArg<T, 'identifier', PrimaryIndexIR>, UsedMethod | 'identifier'>;
     secondaryIndexes<const SecondaryIndexFields = ExtractSecondaryIndexIRFields<T>, const SecondaryIndexPKPool extends string = keyof SecondaryIndexFields & string, const Indexes extends readonly ModelIndexType<string, string, unknown, readonly [], any>[] = readonly [], const IndexesIR extends readonly any[] = SecondaryIndexToIR<Indexes, SecondaryIndexFields>>(callback: (index: <PK extends SecondaryIndexPKPool>(pk: PK) => ModelIndexType<SecondaryIndexPKPool, PK, ReadonlyArray<Exclude<SecondaryIndexPKPool, PK>>>) => Indexes): ModelType<SetTypeSubArg<T, 'secondaryIndexes', IndexesIR>, UsedMethod | 'secondaryIndexes'>;
     disableOperations<const Ops extends ReadonlyArray<DisableOperationsOptions>>(ops: Ops): ModelType<SetTypeSubArg<T, 'disabledOperations', Ops>, UsedMethod | 'disableOperations'>;
-    authorization<AuthRuleType extends Authorization<any, any, any>>(callback: (allow: Omit<AllowModifier, 'resource'>) => AuthRuleType | AuthRuleType[]): ModelType<SetTypeSubArg<T, 'authorization', AuthRuleType[]>, UsedMethod | 'authorization'>;
+    authorization<AuthRuleType extends AnyAuthorization>(callback: (allow: BaseAllowModifier) => AuthRuleType | AuthRuleType[]): ModelType<SetTypeSubArg<T, 'authorization', AuthRuleType[]>, UsedMethod | 'authorization'>;
 }, UsedMethod>;
 ```
-**References:** [ModelType](./data-schema.modeltype.md)<!-- -->, [Authorization](./data-schema.authorization.md)
+**References:** [ModelType](./data-schema.modeltype.md)
 

--- a/packages/data-schema/src/Authorization.ts
+++ b/packages/data-schema/src/Authorization.ts
@@ -708,3 +708,6 @@ export const accessSchemaData = <T extends SchemaAuthorization<any, any, any>>(
 export type AllowModifier = typeof allow;
 export type AllowModifierForCustomOperation = typeof allowForCustomOperations;
 export type AllowModifierForConversations = typeof allowForConversations;
+
+export type BaseAllowModifier = Omit<AllowModifier, 'resource'>;
+export type AnyAuthorization = Authorization<any, any, any>;

--- a/packages/data-schema/src/ModelType.ts
+++ b/packages/data-schema/src/ModelType.ts
@@ -235,7 +235,7 @@ export type ModelType<
      * @returns A ModelType instance with updated identifiers
      *
      * @example
-     * .identifier(['name', 'age'])
+     * model().identifier(['name', 'age'])
      */
     identifier<
       PrimaryIndexFields = ExtractSecondaryIndexIRFields<T>,
@@ -259,7 +259,7 @@ export type ModelType<
      * @returns A ModelType instance with updated secondary index
      *
      * @example
-     * .secondaryIndexes((index) => [index('type').sortKeys(['sort'])])
+     * model().secondaryIndexes((index) => [index('type').sortKeys(['sort'])])
      */
     secondaryIndexes<
       const SecondaryIndexFields = ExtractSecondaryIndexIRFields<T>,
@@ -298,7 +298,7 @@ export type ModelType<
      * @returns A ModelType instance with updated disabled operations
      *
      * @example
-     * model.disableOperations(['queries', 'subscriptions'])
+     * model().disableOperations(['queries', 'subscriptions'])
      */
     disableOperations<
       const Ops extends ReadonlyArray<DisableOperationsOptions>,
@@ -316,7 +316,7 @@ export type ModelType<
      * @returns A ModelType instance with updated authorization rules
      *
      * @example
-     * model.authorization((allow) => [
+     * model().authorization((allow) => [
      *   allow.guest(),
      *   allow.publicApiKey(),
      *   allow.authenticated(),

--- a/packages/data-schema/src/ModelType.ts
+++ b/packages/data-schema/src/ModelType.ts
@@ -10,7 +10,12 @@ import type {
   InternalRelationshipField,
   ModelRelationshipFieldParamShape,
 } from './ModelRelationshipField';
-import { type AllowModifier, type Authorization, allow } from './Authorization';
+import { 
+  type Authorization, 
+  type BaseAllowModifier, 
+  type AnyAuthorization,
+  allow, 
+} from './Authorization';
 import type { RefType, RefTypeParamShape } from './RefType';
 import type { EnumType } from './EnumType';
 import type { CustomType, CustomTypeParamShape } from './CustomType';
@@ -28,9 +33,6 @@ import type { methodKeyOf } from './util/usedMethods.js';
 
 const brandName = 'modelType';
 export type deferredRefResolvingPrefix = 'deferredRefResolving:';
-
-type BaseAllowModifier = Omit<AllowModifier, 'resource'>;
-type AnyAuthorization = Authorization<any, any, any>;
 
 type ModelFields = Record<
   string,
@@ -229,13 +231,17 @@ export type ModelType<
     [brandSymbol]: typeof brandName;
 
     /**
-     * Defines single-field or composite identifiers
+     * Defines single-field or composite identifiers, the fields must be marked required
      *
      * @param identifier A list of field names used as identifiers for the data model
      * @returns A ModelType instance with updated identifiers
      *
      * @example
-     * model().identifier(['name', 'age'])
+     * a.model({
+     *  name: a.string().required(),
+     *  email: a.string().required(),
+     *  age: a.integer(),
+     * }).identifier(['name', 'email'])
      */
     identifier<
       PrimaryIndexFields = ExtractSecondaryIndexIRFields<T>,
@@ -259,7 +265,10 @@ export type ModelType<
      * @returns A ModelType instance with updated secondary index
      *
      * @example
-     * model().secondaryIndexes((index) => [index('type').sortKeys(['sort'])])
+     * a.model().secondaryIndexes((index) => [index('type').sortKeys(['sort'])])
+     * 
+     * @see [Amplify documentation for secondary indexes](https://docs.amplify.aws/react/build-a-backend/data/data-modeling/secondary-index/)
+     * @see [Amazon DynamoDB documentation for secondary indexes](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/SecondaryIndexes.html)
      */
     secondaryIndexes<
       const SecondaryIndexFields = ExtractSecondaryIndexIRFields<T>,
@@ -298,7 +307,9 @@ export type ModelType<
      * @returns A ModelType instance with updated disabled operations
      *
      * @example
-     * model().disableOperations(['queries', 'subscriptions'])
+     * a.model().disableOperations(['delete', 'update', 'queries', 'subscriptions'])
+     * 
+     * @see [Amplify Data documentation for supported operations](https://docs.amplify.aws/react/build-a-backend/data/)
      */
     disableOperations<
       const Ops extends ReadonlyArray<DisableOperationsOptions>,
@@ -316,7 +327,7 @@ export type ModelType<
      * @returns A ModelType instance with updated authorization rules
      *
      * @example
-     * model().authorization((allow) => [
+     * a.model().authorization((allow) => [
      *   allow.guest(),
      *   allow.publicApiKey(),
      *   allow.authenticated(),


### PR DESCRIPTION
*Description of changes:*

This change introduces docstrings on all data model builder methods to demonstrate proper invocation. It also adds type alias to present clearer types for customers.

*Example of why we need this:*

Before the change:
`.authorization()`
<img width="615" alt="Screenshot 2024-12-04 at 2 10 59 PM" src="https://github.com/user-attachments/assets/23b8f5bd-3795-40a0-83ce-19f5f42fea34">

After the change:

`.authorization()`

<img width="571" alt="Screenshot 2025-01-13 at 2 12 48 PM" src="https://github.com/user-attachments/assets/79717615-960f-4d09-96c0-ce576388d3a3" />



`.identifier()`

<img width="549" alt="Screenshot 2025-01-13 at 2 13 19 PM" src="https://github.com/user-attachments/assets/9b3a38b6-5a4d-4f57-8613-e29d0eacb0de" />



`.disableOperations()`

<img width="622" alt="Screenshot 2025-01-13 at 2 12 15 PM" src="https://github.com/user-attachments/assets/34474c76-f06c-4c0c-933e-64c833c6d76c" />




`.secondaryIndexes()`

<img width="612" alt="Screenshot 2025-01-13 at 2 11 01 PM" src="https://github.com/user-attachments/assets/5abade46-9ccb-4967-8cce-b1196479717b" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



