### PR TITLE
style: Code formatting in SchemaProcessor and CustomOperations tests

### DIFF
--- a/.changeset/proud-brooms-explain.md
+++ b/.changeset/proud-brooms-explain.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/data-schema': patch
+---
+
+style: cleanup whitespace and standardize code formatting in data-schema package

--- a/packages/data-schema/__tests__/CustomOperations.test-d.ts
+++ b/packages/data-schema/__tests__/CustomOperations.test-d.ts
@@ -84,7 +84,7 @@ describe('custom operations return types', () => {
     });
 
     it('produces async function handler types', () => {
-      const handler = defineFunctionStub({})
+      const handler = defineFunctionStub({});
       const schema = a.schema({
         aQuery: a
           .query()
@@ -92,7 +92,7 @@ describe('custom operations return types', () => {
           .arguments({
             input: a.string(),
             content: a.string().required(),
-          })
+          }),
       });
 
       type Schema = ClientSchema<typeof schema>;
@@ -109,10 +109,7 @@ describe('custom operations return types', () => {
       type ExpectedResult = {
         success: boolean;
       } | null;
-      type ExpectedFunctionHandler = AppSyncResolverHandler<
-        ActualArgs,
-        void
-      >;
+      type ExpectedFunctionHandler = AppSyncResolverHandler<ActualArgs, void>;
       type _T1 = Expect<Equal<ActualArgs, ExpectedArgs>>;
       type _T2 = Expect<Equal<ActualResult, ExpectedResult>>;
       type _T3 = Expect<Equal<ActualHandler, ExpectedFunctionHandler>>;

--- a/packages/data-schema/__tests__/CustomOperations.test.ts
+++ b/packages/data-schema/__tests__/CustomOperations.test.ts
@@ -907,7 +907,7 @@ describe('CustomOperation transform', () => {
               .query()
               .arguments({})
               .handler(a.handler.function(fn1).async())
-              .authorization((allow) => allow.authenticated())
+              .authorization((allow) => allow.authenticated()),
           });
 
           const { schema, lambdaFunctions } = s.transform();
@@ -915,7 +915,7 @@ describe('CustomOperation transform', () => {
           expect(lambdaFunctions).toMatchObject({
             FnGetPostDetails: fn1,
           });
-        })
+        });
 
         test('defineFunction sync - async', () => {
           const fn1 = defineFunctionStub({});
@@ -927,7 +927,7 @@ describe('CustomOperation transform', () => {
                 a.handler.function(fn1),
                 a.handler.function(fn1).async(),
               ])
-              .authorization((allow) => allow.authenticated())
+              .authorization((allow) => allow.authenticated()),
           });
 
           const { schema, lambdaFunctions } = s.transform();
@@ -935,7 +935,7 @@ describe('CustomOperation transform', () => {
           expect(lambdaFunctions).toMatchObject({
             FnGetPostDetails: fn1,
           });
-        })
+        });
 
         test('defineFunction sync - async with returns generates type errors', () => {
           const fn1 = defineFunctionStub({});
@@ -949,9 +949,9 @@ describe('CustomOperation transform', () => {
               ])
               .authorization((allow) => allow.authenticated())
               // @ts-expect-error
-              .returns({ })
+              .returns({}),
           });
-        })
+        });
 
         test('defineFunction async - async', () => {
           const fn1 = defineFunctionStub({});
@@ -965,7 +965,7 @@ describe('CustomOperation transform', () => {
                 a.handler.function(fn1).async(),
                 a.handler.function(fn2).async(),
               ])
-              .authorization((allow) => allow.authenticated())
+              .authorization((allow) => allow.authenticated()),
           });
 
           const { schema, lambdaFunctions } = s.transform();
@@ -974,7 +974,7 @@ describe('CustomOperation transform', () => {
             FnGetPostDetails: fn1,
             FnGetPostDetails2: fn2,
           });
-        })
+        });
 
         test('defineFunction async - sync', () => {
           const fn1 = defineFunctionStub({});
@@ -987,12 +987,12 @@ describe('CustomOperation transform', () => {
                 a.handler.function(fn1),
               ])
               .returns(a.customType({}))
-              .authorization((allow) => allow.authenticated())
+              .authorization((allow) => allow.authenticated()),
           });
 
           const { schema, lambdaFunctions } = s.transform();
           expect(schema).toMatchSnapshot();
-        })
+        });
 
         test('pipeline / mix', () => {
           const fn1 = defineFunctionStub({});

--- a/packages/data-schema/src/SchemaProcessor.ts
+++ b/packages/data-schema/src/SchemaProcessor.ts
@@ -155,9 +155,7 @@ function isRefField(
   return isRefFieldDef((field as any)?.data);
 }
 
-function canGenerateFieldType(
-  fieldType: ModelFieldType
-): boolean {
+function canGenerateFieldType(fieldType: ModelFieldType): boolean {
   return fieldType === 'Int';
 }
 
@@ -174,7 +172,6 @@ function scalarFieldToGql(
     default: _default,
   } = fieldDef;
   let field: string = fieldType;
-
 
   if (identifier !== undefined) {
     field += '!';
@@ -929,23 +926,33 @@ function processFieldLevelAuthRules(
   return fieldLevelAuthRules;
 }
 
-function validateDBGeneration(fields: Record<string, any>, databaseEngine: DatasourceEngine) {
+function validateDBGeneration(
+  fields: Record<string, any>,
+  databaseEngine: DatasourceEngine,
+) {
   for (const [fieldName, fieldDef] of Object.entries(fields)) {
     const _default = fieldDef.data?.default;
     const fieldType = fieldDef.data?.fieldType;
     const isGenerated = _default === __generated;
 
     if (isGenerated && databaseEngine !== 'postgresql') {
-      throw new Error(`Invalid field definition for ${fieldName}. DB-generated fields are only supported with PostgreSQL data sources.`);
+      throw new Error(
+        `Invalid field definition for ${fieldName}. DB-generated fields are only supported with PostgreSQL data sources.`,
+      );
     }
 
     if (isGenerated && !canGenerateFieldType(fieldType)) {
-      throw new Error(`Incompatible field type. Field type ${fieldType} in field ${fieldName} cannot be configured as a DB-generated field.`);
+      throw new Error(
+        `Incompatible field type. Field type ${fieldType} in field ${fieldName} cannot be configured as a DB-generated field.`,
+      );
     }
   }
 }
 
-function validateNullableIdentifiers(fields: Record<string, any>, identifier?: readonly string[]){
+function validateNullableIdentifiers(
+  fields: Record<string, any>,
+  identifier?: readonly string[],
+) {
   for (const [fieldName, fieldDef] of Object.entries(fields)) {
     const fieldType = fieldDef.data?.fieldType;
     const required = fieldDef.data?.required;
@@ -954,7 +961,9 @@ function validateNullableIdentifiers(fields: Record<string, any>, identifier?: r
 
     if (identifier !== undefined && identifier.includes(fieldName)) {
       if (!required && fieldType !== 'ID' && !isGenerated) {
-        throw new Error(`Invalid identifier definition. Field ${fieldName} cannot be used in the identifier. Identifiers must reference required or DB-generated fields)`);
+        throw new Error(
+          `Invalid identifier definition. Field ${fieldName} cannot be used in the identifier. Identifiers must reference required or DB-generated fields)`,
+        );
       }
     }
   }
@@ -977,7 +986,7 @@ function processFields(
 
   validateImpliedFields(fields, impliedFields);
   validateDBGeneration(fields, databaseEngine);
-  validateNullableIdentifiers(fields, identifier)
+  validateNullableIdentifiers(fields, identifier);
 
   for (const [fieldName, fieldDef] of Object.entries(fields)) {
     const fieldAuth = fieldLevelAuthRules[fieldName]
@@ -1334,11 +1343,8 @@ const schemaPreprocessor = (
   const lambdaFunctions: LambdaFunctionDefinition = {};
   const customSqlDataSourceStrategies: CustomSqlDataSourceStrategy[] = [];
 
-  const databaseEngine = schema.data.configuration.database.engine
-  const databaseType =
-    databaseEngine === 'dynamodb'
-      ? 'dynamodb'
-      : 'sql';
+  const databaseEngine = schema.data.configuration.database.engine;
+  const databaseType = databaseEngine === 'dynamodb' ? 'dynamodb' : 'sql';
 
   const staticSchema = databaseType === 'sql';
 
@@ -1422,7 +1428,7 @@ const schemaPreprocessor = (
           undefined,
           undefined,
           undefined,
-          databaseEngine
+          databaseEngine,
         );
 
         topLevelTypes.push(...implicitTypes);


### PR DESCRIPTION
This PR addresses formatting changes that were originally part of #497. Separating these formatting changes to keep the main PR focused on functional changes.

Files affected:
- SchemaProcessor.ts
- CustomOperations.test-d.ts
- CustomOperations.test.ts

Changes:
- Fix whitespace and indentation inconsistencies
- Standardize code formatting

Related PR: #497
