### PR TITLE
feat: add schema generation for validate builder and additional tests

### DIFF
--- a/.changeset/happy-parents-occur.md
+++ b/.changeset/happy-parents-occur.md
@@ -1,0 +1,7 @@
+---
+'integration-tests': minor
+'@aws-amplify/data-schema': minor
+'benches': minor
+---
+
+improve validate builder's typing, add defined behavior test

--- a/packages/benches/p50/operations/p50-prod-CRUDL.bench.ts
+++ b/packages/benches/p50/operations/p50-prod-CRUDL.bench.ts
@@ -629,4 +629,4 @@ bench('prod p50 CRUDL', async () => {
   });
 
   await client.models.Todo.list();
-}).types([684214, 'instantiations']);
+}).types([692058, 'instantiations']);

--- a/packages/benches/p50/operations/p50-prod-selection-set.bench.ts
+++ b/packages/benches/p50/operations/p50-prod-selection-set.bench.ts
@@ -632,4 +632,4 @@ bench('prod p50 CRUDL', async () => {
   });
 
   await client.models.Todo.list({ selectionSet });
-}).types([707395, 'instantiations']);
+}).types([715279, 'instantiations']);

--- a/packages/benches/p99/within-limit/operations/p99-tall-complex-CRUDL.bench.ts
+++ b/packages/benches/p99/within-limit/operations/p99-tall-complex-CRUDL.bench.ts
@@ -2619,4 +2619,4 @@ bench('99 complex models CRUDL', async () => {
   });
 
   await client.models.FieldLevelAuthModel1.list();
-}).types([496997, 'instantiations']);
+}).types([503326, 'instantiations']);

--- a/packages/benches/p99/within-limit/operations/p99-tall-simple-CRUDL.bench.ts
+++ b/packages/benches/p99/within-limit/operations/p99-tall-simple-CRUDL.bench.ts
@@ -250,4 +250,4 @@ bench('70 simple models with 1 field each w/ client types', async () => {
   await client.models.Model1.delete({ id: result.data!.id });
 
   await client.models.Model1.list();
-}).types([165619, 'instantiations']);
+}).types([168777, 'instantiations']);

--- a/packages/benches/p99/within-limit/operations/p99-tall-simple-selection-set.bench.ts
+++ b/packages/benches/p99/within-limit/operations/p99-tall-simple-selection-set.bench.ts
@@ -252,4 +252,4 @@ bench('70 simple models with 1 field each w/ client types', async () => {
   await client.models.Model1.delete({ id: result.data!.id });
 
   await client.models.Model1.list({ selectionSet });
-}).types([186362, 'instantiations']);
+}).types([189520, 'instantiations']);

--- a/packages/data-schema/__tests__/Validate.test-d.ts
+++ b/packages/data-schema/__tests__/Validate.test-d.ts
@@ -209,39 +209,88 @@ describe('Each validator can only be used once on the same field', () => {
     // @ts-expect-error
     const integerField1 = a.integer().validate(v => v.gt(0).gt(10));
     // @ts-expect-error
-    const integerField2 = a.integer().validate(v => v.lt(0).lt(10));
+    const integerField2 = a.integer().validate(v => v.gt(0).lt(10).gt(0));
+
     // @ts-expect-error
-    const integerField3 = a.integer().validate(v => v.gte(0).gte(10));
+    const integerField3 = a.integer().validate(v => v.lt(0).lt(10));
     // @ts-expect-error
-    const integerField4 = a.integer().validate(v => v.lte(0).lte(10));
+    const integerField4 = a.integer().validate(v => v.lt(0).gt(10).lt(0));
+
     // @ts-expect-error
-    const integerField5 = a.integer().validate(v => v.positive().positive());
+    const integerField5 = a.integer().validate(v => v.gte(0).gte(10));
     // @ts-expect-error
-    const integerField6 = a.integer().validate(v => v.negative().negative());
+    const integerField6 = a.integer().validate(v => v.gte(0).lte(10).gte(0));
+
+    // @ts-expect-error
+    const integerField7 = a.integer().validate(v => v.lte(0).lte(10));
+    // @ts-expect-error
+    const integerField8 = a.integer().validate(v => v.lte(0).gte(10).lte(0));
+
+    // @ts-expect-error
+    const integerField9 = a.integer().validate(v => v.positive().positive());
+    // @ts-expect-error
+    const integerField10 = a.integer().validate(v => v.positive().negative().positive());
+
+    // @ts-expect-error
+    const integerField11 = a.integer().validate(v => v.negative().negative());
+    // @ts-expect-error
+    const integerField12 = a.integer().validate(v => v.negative().positive().negative());
+
     // @ts-expect-error
     const floatField1 = a.float().validate(v => v.gt(0).gt(10));
     // @ts-expect-error
-    const floatField2 = a.float().validate(v => v.lt(0).lt(10));
+    const floatField2 = a.float().validate(v => v.gt(0).lt(10).gt(0));
+
     // @ts-expect-error
-    const floatField3 = a.float().validate(v => v.gte(0).gte(10));
+    const floatField3 = a.float().validate(v => v.lt(0).lt(10));
     // @ts-expect-error
-    const floatField4 = a.float().validate(v => v.lte(0).lte(10));
+    const floatField4 = a.float().validate(v => v.lt(0).gt(10).lt(0));
+
     // @ts-expect-error
-    const floatField5 = a.float().validate(v => v.positive().positive());
+    const floatField5 = a.float().validate(v => v.gte(0).gte(10));
     // @ts-expect-error
-    const floatField6 = a.float().validate(v => v.negative().negative());
+    const floatField6 = a.float().validate(v => v.gte(0).lte(10).gte(0));
+
+    // @ts-expect-error
+    const floatField7 = a.float().validate(v => v.lte(0).lte(10));
+    // @ts-expect-error
+    const floatField8 = a.float().validate(v => v.lte(0).gte(10).lte(0));
+
+    // @ts-expect-error
+    const floatField9 = a.float().validate(v => v.positive().positive());
+    // @ts-expect-error
+    const floatField10 = a.float().validate(v => v.positive().negative().positive());
+
+    // @ts-expect-error
+    const floatField11 = a.float().validate(v => v.negative().negative());
+    // @ts-expect-error
+    const floatField12 = a.float().validate(v => v.negative().positive().negative());
   });
 
   it('String validators can only be used once on the same String field', () => {
     // @ts-expect-error
     const stringField1 = a.string().validate(v => v.minLength(5).minLength(10));
     // @ts-expect-error
-    const stringField2 = a.string().validate(v => v.maxLength(5).maxLength(10));
+    const stringField2 = a.string().validate(v => v.minLength(5).maxLength(10).minLength(10));
+
     // @ts-expect-error
-    const stringField3 = a.string().validate(v => v.startsWith('prefix-').startsWith('prefix-'));
+    const stringField3 = a.string().validate(v => v.maxLength(5).maxLength(10));
     // @ts-expect-error
-    const stringField4 = a.string().validate(v => v.endsWith('-suffix').endsWith('-suffix'));
+    const stringField4 = a.string().validate(v => v.maxLength(5).minLength(10).maxLength(10));
+
     // @ts-expect-error
-    const stringField5 = a.string().validate(v => v.matches('^[a-zA-Z0-9]+$').matches('^[a-zA-Z0-9]+$'));
+    const stringField5 = a.string().validate(v => v.startsWith('prefix-').startsWith('prefix-'));
+    // @ts-expect-error
+    const stringField6 = a.string().validate(v => v.startsWith('prefix-').endsWith('-suffix').startsWith('prefix-'));
+
+    // @ts-expect-error
+    const stringField7 = a.string().validate(v => v.endsWith('prefix-').endsWith('-suffix'));
+    // @ts-expect-error
+    const stringField8 = a.string().validate(v => v.endsWith('-suffix').startsWith('prefix-').endsWith('-suffix'));
+
+    // @ts-expect-error
+    const stringField9 = a.string().validate(v => v.matches('^[a-zA-Z0-9]+$').matches('^[a-zA-Z0-9]+$'));
+    // @ts-expect-error
+    const stringField10 = a.string().validate(v => v.matches('^[a-zA-Z0-9]+$').startsWith('prefix-').matches('^[a-zA-Z0-9]+$'));
   });
 });

--- a/packages/data-schema/__tests__/Validate.test.ts
+++ b/packages/data-schema/__tests__/Validate.test.ts
@@ -53,7 +53,7 @@ describe('Validation directive generation', () => {
     expect(schema.transform().schema).toMatchSnapshot();
   });
   
-  test('Model with various validation rules with error messages', () => {
+  test('Model with various validation rules with double-quoted error messages', () => {
     const schema = a
       .schema({
         TestModelWithErrors: a.model({
@@ -91,6 +91,52 @@ describe('Validation directive generation', () => {
              .startsWith("ABC", "String must start with ABC")
              .endsWith("XYZ", "String must end with XYZ")
              .matches("^[A-Z0-9]+$", "String must only contain uppercase letters and numbers")
+          ),
+        }),
+      })
+      .authorization((allow) => allow.publicApiKey());
+
+    expect(schema.transform().schema).toMatchSnapshot();
+  });
+
+  test('Model with various validation rules with single-quoted error messages', () => {
+    const schema = a
+      .schema({
+        TestModelWithErrors: a.model({
+          id: a.id(),
+          // Integer field with numeric validations
+          integerField: a.integer().validate(v => 
+            v.gt(0, 'Value must be greater than 0')
+             .lt(100, 'Value must be less than 100')
+             .gte(1, 'Value must be at least 1')
+             .lte(99, 'Value must be at most 99')
+          ),
+          positiveIntegerField: a.integer().validate(v => 
+            v.positive('Value must be positive')
+          ),
+          negativeIntegerField: a.integer().validate(v => 
+            v.negative('Value must be negative')
+          ),
+          // Float field with numeric validations
+          floatField: a.float().validate(v => 
+            v.gt(0.99, 'Value must be greater than 0.99')
+             .lt(1000.01, 'Value must be less than 1000.01')
+             .gte(1.0, 'Value must be at least 1.0')
+             .lte(1000.0, 'Value must be at most 1000.0')
+          ),
+          positiveFloatField: a.float().validate(v => 
+            v.positive('Value must be positive')
+          ),
+          negativeFloatField: a.float().validate(v => 
+            v.negative('Value must be negative')
+          ),
+            // String field with string validations
+          stringField: a.string().validate(v => 
+            v.minLength(5, 'String must be at least 5 characters')
+             .maxLength(20, 'String must be at most 20 characters')
+             .startsWith('ABC', 'String must start with ABC')
+             .endsWith('XYZ', 'String must end with XYZ')
+             .matches('^[A-Z0-9]+$', 'String must only contain uppercase letters and numbers')
           ),
         }),
       })

--- a/packages/data-schema/__tests__/Validate.test.ts
+++ b/packages/data-schema/__tests__/Validate.test.ts
@@ -1,0 +1,101 @@
+import { expectTypeTestsToPassAsync } from 'jest-tsd';
+import { a } from '../src/index';
+
+// evaluates type defs in corresponding test-d.ts file
+it('should not produce static type errors', async () => {
+  await expectTypeTestsToPassAsync(__filename);
+});
+
+describe('Validation directive generation', () => {
+  test('Model with various validation rules without error messages', () => {
+    const schema = a
+      .schema({
+        TestModel: a.model({
+          id: a.id(),
+          // Integer field with numeric validations
+          integerField: a.integer().validate(v => 
+            v.gt(0)
+             .lt(100)
+             .gte(1)
+             .lte(99)
+          ),
+          positiveIntegerField: a.integer().validate(v => 
+            v.positive()
+          ),
+          negativeIntegerField: a.integer().validate(v => 
+            v.negative()
+          ),
+          // Float field with numeric validations
+          floatField: a.float().validate(v => 
+            v.gt(0.99)
+             .lt(1000.01)
+             .gte(1.0)
+             .lte(1000.0)
+          ),
+          positiveFloatField: a.float().validate(v => 
+            v.positive()
+          ),
+          negativeFloatField: a.float().validate(v => 
+            v.negative()
+          ),
+          // String field with string validations
+          stringField: a.string().validate(v => 
+            v.minLength(5)
+             .maxLength(20)
+             .startsWith("ABC")
+             .endsWith("XYZ")
+             .matches("^[A-Z0-9]+$")
+          ),
+        }),
+      })
+      .authorization((allow) => allow.publicApiKey());
+
+    expect(schema.transform().schema).toMatchSnapshot();
+  });
+  
+  test('Model with various validation rules with error messages', () => {
+    const schema = a
+      .schema({
+        TestModelWithErrors: a.model({
+          id: a.id(),
+          // Integer field with numeric validations
+          integerField: a.integer().validate(v => 
+            v.gt(0, "Value must be greater than 0")
+             .lt(100, "Value must be less than 100")
+             .gte(1, "Value must be at least 1")
+             .lte(99, "Value must be at most 99")
+          ),
+          positiveIntegerField: a.integer().validate(v => 
+            v.positive("Value must be positive")
+          ),
+          negativeIntegerField: a.integer().validate(v => 
+            v.negative("Value must be negative")
+          ),
+          // Float field with numeric validations
+          floatField: a.float().validate(v => 
+            v.gt(0.99, "Value must be greater than 0.99")
+             .lt(1000.01, "Value must be less than 1000.01")
+             .gte(1.0, "Value must be at least 1.0")
+             .lte(1000.0, "Value must be at most 1000.0")
+          ),
+          positiveFloatField: a.float().validate(v => 
+            v.positive("Value must be positive")
+          ),
+          negativeFloatField: a.float().validate(v => 
+            v.negative("Value must be negative")
+          ),
+          // String field with string validations
+          stringField: a.string().validate(v => 
+            v.minLength(5, "String must be at least 5 characters")
+             .maxLength(20, "String must be at most 20 characters")
+             .startsWith("ABC", "String must start with ABC")
+             .endsWith("XYZ", "String must end with XYZ")
+             .matches("^[A-Z0-9]+$", "String must only contain uppercase letters and numbers")
+          ),
+        }),
+      })
+      .authorization((allow) => allow.publicApiKey());
+
+    expect(schema.transform().schema).toMatchSnapshot();
+  });
+});

--- a/packages/data-schema/__tests__/__snapshots__/Validate.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/Validate.test.ts.snap
@@ -1,6 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Validation directive generation Model with various validation rules with double-quoted error messages 1`] = `
+"type TestModelWithErrors @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  id: ID! @primaryKey
+  integerField: Int @validate(type: gt, value: "0", errorMessage: ""Value must be greater than 0"") @validate(type: lt, value: "100", errorMessage: ""Value must be less than 100"") @validate(type: gte, value: "1", errorMessage: ""Value must be at least 1"") @validate(type: lte, value: "99", errorMessage: ""Value must be at most 99"")
+  positiveIntegerField: Int @validate(type: gt, value: "0", errorMessage: ""Value must be positive"")
+  negativeIntegerField: Int @validate(type: lt, value: "0", errorMessage: ""Value must be negative"")
+  floatField: Float @validate(type: gt, value: "0.99", errorMessage: ""Value must be greater than 0.99"") @validate(type: lt, value: "1000.01", errorMessage: ""Value must be less than 1000.01"") @validate(type: gte, value: "1", errorMessage: ""Value must be at least 1.0"") @validate(type: lte, value: "1000", errorMessage: ""Value must be at most 1000.0"")
+  positiveFloatField: Float @validate(type: gt, value: "0", errorMessage: ""Value must be positive"")
+  negativeFloatField: Float @validate(type: lt, value: "0", errorMessage: ""Value must be negative"")
+  stringField: String @validate(type: minLength, value: "5", errorMessage: ""String must be at least 5 characters"") @validate(type: maxLength, value: "20", errorMessage: ""String must be at most 20 characters"") @validate(type: startsWith, value: "ABC", errorMessage: ""String must start with ABC"") @validate(type: endsWith, value: "XYZ", errorMessage: ""String must end with XYZ"") @validate(type: matches, value: "^[A-Z0-9]+$", errorMessage: ""String must only contain uppercase letters and numbers"")
+}"
+`;
+
 exports[`Validation directive generation Model with various validation rules with error messages 1`] = `
+"type TestModelWithErrors @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  id: ID! @primaryKey
+  integerField: Int @validate(type: gt, value: "0", errorMessage: ""Value must be greater than 0"") @validate(type: lt, value: "100", errorMessage: ""Value must be less than 100"") @validate(type: gte, value: "1", errorMessage: ""Value must be at least 1"") @validate(type: lte, value: "99", errorMessage: ""Value must be at most 99"")
+  positiveIntegerField: Int @validate(type: gt, value: "0", errorMessage: ""Value must be positive"")
+  negativeIntegerField: Int @validate(type: lt, value: "0", errorMessage: ""Value must be negative"")
+  floatField: Float @validate(type: gt, value: "0.99", errorMessage: ""Value must be greater than 0.99"") @validate(type: lt, value: "1000.01", errorMessage: ""Value must be less than 1000.01"") @validate(type: gte, value: "1", errorMessage: ""Value must be at least 1.0"") @validate(type: lte, value: "1000", errorMessage: ""Value must be at most 1000.0"")
+  positiveFloatField: Float @validate(type: gt, value: "0", errorMessage: ""Value must be positive"")
+  negativeFloatField: Float @validate(type: lt, value: "0", errorMessage: ""Value must be negative"")
+  stringField: String @validate(type: minLength, value: "5", errorMessage: ""String must be at least 5 characters"") @validate(type: maxLength, value: "20", errorMessage: ""String must be at most 20 characters"") @validate(type: startsWith, value: "ABC", errorMessage: ""String must start with ABC"") @validate(type: endsWith, value: "XYZ", errorMessage: ""String must end with XYZ"") @validate(type: matches, value: "^[A-Z0-9]+$", errorMessage: ""String must only contain uppercase letters and numbers"")
+}"
+`;
+
+exports[`Validation directive generation Model with various validation rules with single-quoted error messages 1`] = `
 "type TestModelWithErrors @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   id: ID! @primaryKey

--- a/packages/data-schema/__tests__/__snapshots__/Validate.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/Validate.test.ts.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Validation directive generation Model with various validation rules with error messages 1`] = `
+"type TestModelWithErrors @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  id: ID! @primaryKey
+  integerField: Int @validate(type: gt, value: "0", errorMessage: ""Value must be greater than 0"") @validate(type: lt, value: "100", errorMessage: ""Value must be less than 100"") @validate(type: gte, value: "1", errorMessage: ""Value must be at least 1"") @validate(type: lte, value: "99", errorMessage: ""Value must be at most 99"")
+  positiveIntegerField: Int @validate(type: gt, value: "0", errorMessage: ""Value must be positive"")
+  negativeIntegerField: Int @validate(type: lt, value: "0", errorMessage: ""Value must be negative"")
+  floatField: Float @validate(type: gt, value: "0.99", errorMessage: ""Value must be greater than 0.99"") @validate(type: lt, value: "1000.01", errorMessage: ""Value must be less than 1000.01"") @validate(type: gte, value: "1", errorMessage: ""Value must be at least 1.0"") @validate(type: lte, value: "1000", errorMessage: ""Value must be at most 1000.0"")
+  positiveFloatField: Float @validate(type: gt, value: "0", errorMessage: ""Value must be positive"")
+  negativeFloatField: Float @validate(type: lt, value: "0", errorMessage: ""Value must be negative"")
+  stringField: String @validate(type: minLength, value: "5", errorMessage: ""String must be at least 5 characters"") @validate(type: maxLength, value: "20", errorMessage: ""String must be at most 20 characters"") @validate(type: startsWith, value: "ABC", errorMessage: ""String must start with ABC"") @validate(type: endsWith, value: "XYZ", errorMessage: ""String must end with XYZ"") @validate(type: matches, value: "^[A-Z0-9]+$", errorMessage: ""String must only contain uppercase letters and numbers"")
+}"
+`;
+
+exports[`Validation directive generation Model with various validation rules without error messages 1`] = `
+"type TestModel @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  id: ID! @primaryKey
+  integerField: Int @validate(type: gt, value: "0") @validate(type: lt, value: "100") @validate(type: gte, value: "1") @validate(type: lte, value: "99")
+  positiveIntegerField: Int @validate(type: gt, value: "0")
+  negativeIntegerField: Int @validate(type: lt, value: "0")
+  floatField: Float @validate(type: gt, value: "0.99") @validate(type: lt, value: "1000.01") @validate(type: gte, value: "1") @validate(type: lte, value: "1000")
+  positiveFloatField: Float @validate(type: gt, value: "0")
+  negativeFloatField: Float @validate(type: lt, value: "0")
+  stringField: String @validate(type: minLength, value: "5") @validate(type: maxLength, value: "20") @validate(type: startsWith, value: "ABC") @validate(type: endsWith, value: "XYZ") @validate(type: matches, value: "^[A-Z0-9]+$")
+}"
+`;

--- a/packages/data-schema/__tests__/__snapshots__/Validate.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/Validate.test.ts.snap
@@ -4,27 +4,13 @@ exports[`Validation directive generation Model with various validation rules wit
 "type TestModelWithErrors @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   id: ID! @primaryKey
-  integerField: Int @validate(type: gt, value: "0", errorMessage: ""Value must be greater than 0"") @validate(type: lt, value: "100", errorMessage: ""Value must be less than 100"") @validate(type: gte, value: "1", errorMessage: ""Value must be at least 1"") @validate(type: lte, value: "99", errorMessage: ""Value must be at most 99"")
-  positiveIntegerField: Int @validate(type: gt, value: "0", errorMessage: ""Value must be positive"")
-  negativeIntegerField: Int @validate(type: lt, value: "0", errorMessage: ""Value must be negative"")
-  floatField: Float @validate(type: gt, value: "0.99", errorMessage: ""Value must be greater than 0.99"") @validate(type: lt, value: "1000.01", errorMessage: ""Value must be less than 1000.01"") @validate(type: gte, value: "1", errorMessage: ""Value must be at least 1.0"") @validate(type: lte, value: "1000", errorMessage: ""Value must be at most 1000.0"")
-  positiveFloatField: Float @validate(type: gt, value: "0", errorMessage: ""Value must be positive"")
-  negativeFloatField: Float @validate(type: lt, value: "0", errorMessage: ""Value must be negative"")
-  stringField: String @validate(type: minLength, value: "5", errorMessage: ""String must be at least 5 characters"") @validate(type: maxLength, value: "20", errorMessage: ""String must be at most 20 characters"") @validate(type: startsWith, value: "ABC", errorMessage: ""String must start with ABC"") @validate(type: endsWith, value: "XYZ", errorMessage: ""String must end with XYZ"") @validate(type: matches, value: "^[A-Z0-9]+$", errorMessage: ""String must only contain uppercase letters and numbers"")
-}"
-`;
-
-exports[`Validation directive generation Model with various validation rules with error messages 1`] = `
-"type TestModelWithErrors @model @auth(rules: [{allow: public, provider: apiKey}])
-{
-  id: ID! @primaryKey
-  integerField: Int @validate(type: gt, value: "0", errorMessage: ""Value must be greater than 0"") @validate(type: lt, value: "100", errorMessage: ""Value must be less than 100"") @validate(type: gte, value: "1", errorMessage: ""Value must be at least 1"") @validate(type: lte, value: "99", errorMessage: ""Value must be at most 99"")
-  positiveIntegerField: Int @validate(type: gt, value: "0", errorMessage: ""Value must be positive"")
-  negativeIntegerField: Int @validate(type: lt, value: "0", errorMessage: ""Value must be negative"")
-  floatField: Float @validate(type: gt, value: "0.99", errorMessage: ""Value must be greater than 0.99"") @validate(type: lt, value: "1000.01", errorMessage: ""Value must be less than 1000.01"") @validate(type: gte, value: "1", errorMessage: ""Value must be at least 1.0"") @validate(type: lte, value: "1000", errorMessage: ""Value must be at most 1000.0"")
-  positiveFloatField: Float @validate(type: gt, value: "0", errorMessage: ""Value must be positive"")
-  negativeFloatField: Float @validate(type: lt, value: "0", errorMessage: ""Value must be negative"")
-  stringField: String @validate(type: minLength, value: "5", errorMessage: ""String must be at least 5 characters"") @validate(type: maxLength, value: "20", errorMessage: ""String must be at most 20 characters"") @validate(type: startsWith, value: "ABC", errorMessage: ""String must start with ABC"") @validate(type: endsWith, value: "XYZ", errorMessage: ""String must end with XYZ"") @validate(type: matches, value: "^[A-Z0-9]+$", errorMessage: ""String must only contain uppercase letters and numbers"")
+  integerField: Int @validate(type: gt, value: "0", errorMessage: "Value must be greater than 0") @validate(type: lt, value: "100", errorMessage: "Value must be less than 100") @validate(type: gte, value: "1", errorMessage: "Value must be at least 1") @validate(type: lte, value: "99", errorMessage: "Value must be at most 99")
+  positiveIntegerField: Int @validate(type: gt, value: "0", errorMessage: "Value must be positive")
+  negativeIntegerField: Int @validate(type: lt, value: "0", errorMessage: "Value must be negative")
+  floatField: Float @validate(type: gt, value: "0.99", errorMessage: "Value must be greater than 0.99") @validate(type: lt, value: "1000.01", errorMessage: "Value must be less than 1000.01") @validate(type: gte, value: "1", errorMessage: "Value must be at least 1.0") @validate(type: lte, value: "1000", errorMessage: "Value must be at most 1000.0")
+  positiveFloatField: Float @validate(type: gt, value: "0", errorMessage: "Value must be positive")
+  negativeFloatField: Float @validate(type: lt, value: "0", errorMessage: "Value must be negative")
+  stringField: String @validate(type: minLength, value: "5", errorMessage: "String must be at least 5 characters") @validate(type: maxLength, value: "20", errorMessage: "String must be at most 20 characters") @validate(type: startsWith, value: "ABC", errorMessage: "String must start with ABC") @validate(type: endsWith, value: "XYZ", errorMessage: "String must end with XYZ") @validate(type: matches, value: "^[A-Z0-9]+$", errorMessage: "String must only contain uppercase letters and numbers")
 }"
 `;
 
@@ -32,13 +18,13 @@ exports[`Validation directive generation Model with various validation rules wit
 "type TestModelWithErrors @model @auth(rules: [{allow: public, provider: apiKey}])
 {
   id: ID! @primaryKey
-  integerField: Int @validate(type: gt, value: "0", errorMessage: ""Value must be greater than 0"") @validate(type: lt, value: "100", errorMessage: ""Value must be less than 100"") @validate(type: gte, value: "1", errorMessage: ""Value must be at least 1"") @validate(type: lte, value: "99", errorMessage: ""Value must be at most 99"")
-  positiveIntegerField: Int @validate(type: gt, value: "0", errorMessage: ""Value must be positive"")
-  negativeIntegerField: Int @validate(type: lt, value: "0", errorMessage: ""Value must be negative"")
-  floatField: Float @validate(type: gt, value: "0.99", errorMessage: ""Value must be greater than 0.99"") @validate(type: lt, value: "1000.01", errorMessage: ""Value must be less than 1000.01"") @validate(type: gte, value: "1", errorMessage: ""Value must be at least 1.0"") @validate(type: lte, value: "1000", errorMessage: ""Value must be at most 1000.0"")
-  positiveFloatField: Float @validate(type: gt, value: "0", errorMessage: ""Value must be positive"")
-  negativeFloatField: Float @validate(type: lt, value: "0", errorMessage: ""Value must be negative"")
-  stringField: String @validate(type: minLength, value: "5", errorMessage: ""String must be at least 5 characters"") @validate(type: maxLength, value: "20", errorMessage: ""String must be at most 20 characters"") @validate(type: startsWith, value: "ABC", errorMessage: ""String must start with ABC"") @validate(type: endsWith, value: "XYZ", errorMessage: ""String must end with XYZ"") @validate(type: matches, value: "^[A-Z0-9]+$", errorMessage: ""String must only contain uppercase letters and numbers"")
+  integerField: Int @validate(type: gt, value: "0", errorMessage: "Value must be greater than 0") @validate(type: lt, value: "100", errorMessage: "Value must be less than 100") @validate(type: gte, value: "1", errorMessage: "Value must be at least 1") @validate(type: lte, value: "99", errorMessage: "Value must be at most 99")
+  positiveIntegerField: Int @validate(type: gt, value: "0", errorMessage: "Value must be positive")
+  negativeIntegerField: Int @validate(type: lt, value: "0", errorMessage: "Value must be negative")
+  floatField: Float @validate(type: gt, value: "0.99", errorMessage: "Value must be greater than 0.99") @validate(type: lt, value: "1000.01", errorMessage: "Value must be less than 1000.01") @validate(type: gte, value: "1", errorMessage: "Value must be at least 1.0") @validate(type: lte, value: "1000", errorMessage: "Value must be at most 1000.0")
+  positiveFloatField: Float @validate(type: gt, value: "0", errorMessage: "Value must be positive")
+  negativeFloatField: Float @validate(type: lt, value: "0", errorMessage: "Value must be negative")
+  stringField: String @validate(type: minLength, value: "5", errorMessage: "String must be at least 5 characters") @validate(type: maxLength, value: "20", errorMessage: "String must be at most 20 characters") @validate(type: startsWith, value: "ABC", errorMessage: "String must start with ABC") @validate(type: endsWith, value: "XYZ", errorMessage: "String must end with XYZ") @validate(type: matches, value: "^[A-Z0-9]+$", errorMessage: "String must only contain uppercase letters and numbers")
 }"
 `;
 

--- a/packages/data-schema/src/SchemaProcessor.ts
+++ b/packages/data-schema/src/SchemaProcessor.ts
@@ -170,6 +170,7 @@ function scalarFieldToGql(
     array,
     arrayRequired,
     default: _default,
+    validation = [],
   } = fieldDef;
   let field: string = fieldType;
 
@@ -216,6 +217,17 @@ function scalarFieldToGql(
   for (const index of secondaryIndexes) {
     field += ` ${index}`;
   }
+  
+  // Add validation directives for each validation rule
+  for (const validationRule of validation) {
+    const valueStr = typeof validationRule.value === 'number' ? validationRule.value.toString() : validationRule.value;
+    if (validationRule.errorMessage) {
+      field += ` @validate(type: ${validationRule.type}, value: "${valueStr}", errorMessage: "${escapeGraphQlString(validationRule.errorMessage)}")`;
+    } else {
+      field += ` @validate(type: ${validationRule.type}, value: "${valueStr}")`;
+    }
+  }
+  
   return field;
 }
 

--- a/packages/data-schema/src/SchemaProcessor.ts
+++ b/packages/data-schema/src/SchemaProcessor.ts
@@ -222,7 +222,7 @@ function scalarFieldToGql(
   for (const validationRule of validation) {
     const valueStr = typeof validationRule.value === 'number' ? validationRule.value.toString() : validationRule.value;
     if (validationRule.errorMessage) {
-      field += ` @validate(type: ${validationRule.type}, value: "${valueStr}", errorMessage: "${escapeGraphQlString(validationRule.errorMessage)}")`;
+      field += ` @validate(type: ${validationRule.type}, value: "${valueStr}", errorMessage: ${escapeGraphQlString(validationRule.errorMessage)})`;
     } else {
       field += ` @validate(type: ${validationRule.type}, value: "${valueStr}")`;
     }

--- a/packages/data-schema/src/Validate.ts
+++ b/packages/data-schema/src/Validate.ts
@@ -38,7 +38,7 @@ interface InternalValidationBuilder {
 /**
  * Interface for string validation methods without any exclusions
  */
-export interface StringValidationBuilderBase<T> {
+export interface StringValidationBuilderBase<T, ExcludedMethods extends string = never> {
   /**
    * Validates that a string field has at least the specified length
    * ⚠️ Only applicable to string fields
@@ -50,7 +50,10 @@ export interface StringValidationBuilderBase<T> {
    * @param length - The minimum length required
    * @param errorMessage - Optional custom error message
    */
-  minLength(length: number, errorMessage?: string): StringValidationBuilder<T, 'minLength'>;
+  minLength(
+    length: number, 
+    errorMessage?: string
+  ): StringValidationBuilder<T, ExcludedMethods | 'minLength'>;
   
   /**
    * Validates that a string field does not exceed the specified length
@@ -63,7 +66,10 @@ export interface StringValidationBuilderBase<T> {
    * @param length - The maximum length allowed
    * @param errorMessage - Optional custom error message
    */
-  maxLength(length: number, errorMessage?: string): StringValidationBuilder<T, 'maxLength'>;
+  maxLength(
+    length: number, 
+    errorMessage?: string
+  ): StringValidationBuilder<T, ExcludedMethods | 'maxLength'>;
   
   /**
    * Validates that a string field starts with the specified prefix
@@ -76,7 +82,10 @@ export interface StringValidationBuilderBase<T> {
    * @param prefix - The prefix the string must start with
    * @param errorMessage - Optional custom error message
    */
-  startsWith(prefix: string, errorMessage?: string): StringValidationBuilder<T, 'startsWith'>;
+  startsWith(
+    prefix: string, 
+    errorMessage?: string
+  ): StringValidationBuilder<T, ExcludedMethods | 'startsWith'>;
   
   /**
    * Validates that a string field ends with the specified suffix
@@ -89,7 +98,10 @@ export interface StringValidationBuilderBase<T> {
    * @param suffix - The suffix the string must end with
    * @param errorMessage - Optional custom error message
    */
-  endsWith(suffix: string, errorMessage?: string): StringValidationBuilder<T, 'endsWith'>;
+  endsWith(
+    suffix: string, 
+    errorMessage?: string
+  ): StringValidationBuilder<T, ExcludedMethods | 'endsWith'>;
   
   /**
    * Validates that a string field matches the specified regular expression pattern
@@ -102,7 +114,10 @@ export interface StringValidationBuilderBase<T> {
    * @param pattern - The regex pattern the string must match
    * @param errorMessage - Optional custom error message
    */
-  matches(pattern: string, errorMessage?: string): StringValidationBuilder<T, 'matches'>;
+  matches(
+    pattern: string, 
+    errorMessage?: string
+  ): StringValidationBuilder<T, ExcludedMethods | 'matches'>;
 }
 
 /**
@@ -111,12 +126,12 @@ export interface StringValidationBuilderBase<T> {
  * This is to disallow duplicate validation operators on the same field, which is not supported in the Validate Transformer.
  */
 export type StringValidationBuilder<T, ExcludedMethods extends string = never> = 
-  Omit<StringValidationBuilderBase<T>, ExcludedMethods & keyof StringValidationBuilderBase<T>>;
+  Omit<StringValidationBuilderBase<T, ExcludedMethods>, ExcludedMethods & keyof StringValidationBuilderBase<T, ExcludedMethods>>;
 
 /**
  * Interface for numeric validation methods without any exclusions
  */
-export interface NumericValidationBuilderBase<T> {
+export interface NumericValidationBuilderBase<T, ExcludedMethods extends string = never> {
   /**
    * Validates that a numeric field is greater than the specified value
    * ⚠️ Only applicable for integer or float fields
@@ -131,8 +146,11 @@ export interface NumericValidationBuilderBase<T> {
    * @param value - The value that the field must be greater than
    * @param errorMessage - Optional custom error message
    */
-  gt(value: number, errorMessage?: string): NumericValidationBuilder<T, 'gt' | 'positive'>;
-  
+  gt(
+    value: number, 
+    errorMessage?: string
+  ): NumericValidationBuilder<T, ExcludedMethods | 'gt' | 'positive'>;
+
   /**
    * Validates that a numeric field is less than the specified value
    * ⚠️ Only applicable for integer or float fields
@@ -147,7 +165,10 @@ export interface NumericValidationBuilderBase<T> {
    * @param value - The value that the field must be less than
    * @param errorMessage - Optional custom error message
    */
-  lt(value: number, errorMessage?: string): NumericValidationBuilder<T, 'lt' | 'negative'>;
+  lt(
+    value: number, 
+    errorMessage?: string
+  ): NumericValidationBuilder<T, ExcludedMethods | 'lt' | 'negative'>;
   
   /**
    * Validates that a numeric field is greater than or equal to the specified value
@@ -163,7 +184,10 @@ export interface NumericValidationBuilderBase<T> {
    * @param value - The value that the field must be greater than or equal to
    * @param errorMessage - Optional custom error message
    */
-  gte(value: number, errorMessage?: string): NumericValidationBuilder<T, 'gte'>;
+  gte(
+    value: number, 
+    errorMessage?: string
+  ): NumericValidationBuilder<T, ExcludedMethods | 'gte'>;
   
   /**
    * Validates that a numeric field is less than or equal to the specified value
@@ -179,7 +203,10 @@ export interface NumericValidationBuilderBase<T> {
    * @param value - The value that the field must be less than or equal to
    * @param errorMessage - Optional custom error message
    */
-  lte(value: number, errorMessage?: string): NumericValidationBuilder<T, 'lte'>;
+  lte(
+    value: number, 
+    errorMessage?: string
+  ): NumericValidationBuilder<T, ExcludedMethods | 'lte'>;
 
   /**
    * Validates that a numeric field is positive
@@ -194,7 +221,9 @@ export interface NumericValidationBuilderBase<T> {
    * 
    * @param errorMessage - Optional custom error message
    */
-  positive(errorMessage?: string): NumericValidationBuilder<T, 'positive' | 'gt'>;
+  positive(
+    errorMessage?: string
+  ): NumericValidationBuilder<T, ExcludedMethods | 'positive' | 'gt'>;
 
   /**
    * Validates that a numeric field is negative
@@ -209,7 +238,9 @@ export interface NumericValidationBuilderBase<T> {
    * 
    * @param errorMessage - Optional custom error message
    */
-  negative(errorMessage?: string): NumericValidationBuilder<T, 'negative' | 'lt'>;
+  negative(
+    errorMessage?: string
+  ): NumericValidationBuilder<T, ExcludedMethods | 'negative' | 'lt'>;
 }
 
 /**
@@ -218,7 +249,7 @@ export interface NumericValidationBuilderBase<T> {
  * This is to disallow duplicate validation operators on the same field, which is not supported in the Validate Transformer.
  */
 export type NumericValidationBuilder<T, ExcludedMethods extends string = never> = 
-  Omit<NumericValidationBuilderBase<T>, ExcludedMethods & keyof NumericValidationBuilderBase<T>>;
+  Omit<NumericValidationBuilderBase<T, ExcludedMethods>, ExcludedMethods & keyof NumericValidationBuilderBase<T, ExcludedMethods>>;
 
 /**
  * Maps a ModelFieldType to the appropriate validation builder type
@@ -227,9 +258,9 @@ export type NumericValidationBuilder<T, ExcludedMethods extends string = never> 
  */
 export type FieldTypeToValidationBuilder<T, FT extends ModelFieldType> = 
   FT extends ModelFieldType.String
-    ? StringValidationBuilder<T>
+    ? StringValidationBuilder<T, never>
     : FT extends ModelFieldType.Integer | ModelFieldType.Float
-      ? NumericValidationBuilder<T>
+      ? NumericValidationBuilder<T, never>
       : never;
 
 /**

--- a/packages/integration-tests/__tests__/defined-behavior/2-expected-use/validate-builder.ts
+++ b/packages/integration-tests/__tests__/defined-behavior/2-expected-use/validate-builder.ts
@@ -1,87 +1,452 @@
 import { a, ClientSchema } from '@aws-amplify/data-schema';
 import { Amplify } from 'aws-amplify';
-import { buildAmplifyConfig, mockedGenerateClient } from '../../utils';
+import { buildAmplifyConfig, mockedGenerateClient, expectVariables } from '../../utils';
+import { GraphQLError } from 'graphql';
 
 describe('Validate Builder', () => {
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('String Field Validations', () => {
-    test('accumulates string validators correctly', async () => {
-      // Build a schema with a model that uses multiple string validations.
-      const schema = a.schema({
-        Post: a.model({
-          title: a.string().validate(v => 
-            v.minLength(5, 'Title must be at least 5 characters')
-             .maxLength(100, 'Title must be at most 100 characters')
-             .startsWith('post-', 'Title must start with post-')
-          ),
-        }).authorization((allow) => allow.publicApiKey()),
-      });
+  describe('Validate Builder', () => {
+    const schema = a.schema({
+      Post: a.model({
+        title: a.string().validate(v =>
+          v.minLength(5, 'Title must be at least 5 characters')
+           .maxLength(200, 'Title must be at most 200 characters')
+        ),
+        slug: a.string().validate(v =>
+          v.matches('^[a-z0-9-]+$', 'Slug must contain only lowercase letters, numbers, and hyphens')
+        ),
+        summary: a.string().validate(v =>
+          v.maxLength(500, 'Summary must be at most 500 characters')
+        ),
+        content: a.string().validate(v =>
+          v.minLength(20, 'Content must be at least 20 characters')
+        ),
+      }).authorization((allow) => allow.publicApiKey()),
+    
+      Coupon: a.model({
+        code: a.string().validate(v =>
+          v.startsWith('CPN-', 'Code must start with CPN-')
+           .endsWith('-2025', 'Code must end with -2025')
+        ),
+      }).authorization((allow) => allow.publicApiKey()),
+    
+      Product: a.model({
+        price: a.float().validate(v => 
+          v.positive('Price must be positive')
+           .lt(10000, 'Price must be less than 10000')
+        ),
+        rating: a.float().validate(v =>
+          v.gte(0, 'Rating must be at least 0')
+           .lte(5, 'Rating must be at most 5')
+        ),
+        stock: a.integer().validate(v =>
+          v.gte(0, 'Stock must be at least 0')
+           .lte(1000, 'Stock must be at most 1000')
+        ),
+        profit: a.float().validate(v =>
+          v.gt(0, 'Profit must be greater than 0')
+        ),
+        loss: a.float().validate(v =>
+          v.negative('Loss must be negative')
+        ),
+      }).authorization((allow) => allow.publicApiKey()),
+    });
+
+    type Schema = ClientSchema<typeof schema>;
+    
+    const createMockResponse = (modelName: string, data: any, errors?: GraphQLError[]) => ({
+      data: { [`create${modelName}`]: data },
+      errors
+    });
+    
+    const updateMockResponse = (modelName: string, data: any, errors?: GraphQLError[]) => ({
+      data: { [`update${modelName}`]: data },
+      errors
+    });
+    
+    // Mock responses organized by model
+    const mockResponses = [
+      // Post responses
+      createMockResponse('Post', { 
+        id: 'post-id-1', 
+        title: 'Valid title', 
+        slug: 'valid-slug-123', 
+        summary: 'A valid summary', 
+        content: 'This is valid content that is longer than 20 characters.' 
+      }),
+      updateMockResponse('Post', { 
+        id: 'post-id-1', 
+        title: 'Updated title', 
+        slug: 'updated-slug-123', 
+        summary: 'An updated summary', 
+        content: 'This is updated content that is longer than 20 characters.' 
+      }),
+      createMockResponse('Post', { 
+        id: 'post-id-short-title', 
+        title: 'Hi', // Too short, violates minLength(5)
+        slug: 'valid-slug',
+        summary: 'Summary',
+        content: 'Long enough content here'
+      }, [new GraphQLError('Validation error: Title must be at least 5 characters')]),
+      updateMockResponse('Post', {
+        id: 'post-id-invalid-slug', 
+        title: 'Valid title',
+        slug: 'INVALID_SLUG', // Contains uppercase and underscore
+        summary: 'Summary',
+        content: 'Long enough content here'
+      }, [new GraphQLError('Validation error: Slug must contain only lowercase letters, numbers, and hyphens')]),
+      createMockResponse('Post', { 
+        id: 'post-id-long-summary', 
+        title: 'Valid title',
+        slug: 'valid-slug',
+        summary: 'A'.repeat(501), // Too long
+        content: 'Long enough content here'
+      }, [new GraphQLError('Validation error: Summary must be at most 500 characters')]),
+      updateMockResponse('Post', {
+        id: 'post-id-short-content', 
+        title: 'Valid title',
+        slug: 'valid-slug',
+        summary: 'Summary',
+        content: 'Too short' // Too short
+      }, [new GraphQLError('Validation error: Content must be at least 20 characters')]),
       
-      // Build config, configure Amplify, and generate the client.
+      // Coupon responses
+      createMockResponse('Coupon', {
+        id: 'coupon-id-1',
+        code: 'CPN-SUMMER-2025'
+      }),
+      updateMockResponse('Coupon', {
+        id: 'coupon-id-1',
+        code: 'CPN-WINTER-2025'
+      }),
+      createMockResponse('Coupon', {
+        id: 'coupon-id-wrong-prefix',
+        code: 'COUPON-SUMMER-2025' // Wrong prefix
+      }, [new GraphQLError('Validation error: Code must start with CPN-')]),
+      updateMockResponse('Coupon', {
+        id: 'coupon-id-wrong-suffix',
+        code: 'CPN-SUMMER-2024' // Wrong suffix
+      }, [new GraphQLError('Validation error: Code must end with -2025')]),
+      
+      // Product responses
+      createMockResponse('Product', {
+        id: 'product-id-1',
+        price: 99.99,
+        rating: 4.5,
+        stock: 100,
+        profit: 25.50,
+        loss: -10.25
+      }),
+      updateMockResponse('Product', {
+        id: 'product-id-1',
+        price: 129.99,
+        rating: 4.8,
+        stock: 75,
+        profit: 35.50,
+        loss: -5.25
+      }),
+      updateMockResponse('Product', {
+        id: 'product-id-negative-price',
+        price: -10.00, // Negative
+        rating: 4.5,
+        stock: 100,
+        profit: 25.50,
+        loss: -10.25
+      }, [new GraphQLError('Validation error: Price must be positive')]),
+      createMockResponse('Product', {
+        id: 'product-id-high-price',
+        price: 15000.00, // Too high
+        rating: 4.5,
+        stock: 100,
+        profit: 25.50,
+        loss: -10.25
+      }, [new GraphQLError('Validation error: Price must be less than 10000')]),
+      updateMockResponse('Product', {
+        id: 'product-id-negative-rating',
+        price: 99.99,
+        rating: -1.0, // Below minimum
+        stock: 100,
+        profit: 25.50,
+        loss: -10.25
+      }, [new GraphQLError('Validation error: Rating must be at least 0')]),
+      createMockResponse('Product', {
+        id: 'product-id-high-rating',
+        price: 99.99,
+        rating: 6.0, // Above maximum
+        stock: 100,
+        profit: 25.50,
+        loss: -10.25
+      }, [new GraphQLError('Validation error: Rating must be at most 5')]),
+      updateMockResponse('Product', {
+        id: 'product-id-negative-stock',
+        price: 99.99,
+        rating: 4.5,
+        stock: -10, // Negative
+        profit: 25.50,
+        loss: -10.25
+      }, [new GraphQLError('Validation error: Stock must be at least 0')]),
+      createMockResponse('Product', {
+        id: 'product-id-high-stock',
+        price: 99.99,
+        rating: 4.5,
+        stock: 1500, // Too high
+        profit: 25.50,
+        loss: -10.25
+      }, [new GraphQLError('Validation error: Stock must be at most 1000')]),
+      createMockResponse('Product', {
+        id: 'product-id-zero-profit',
+        price: 99.99,
+        rating: 4.5,
+        stock: 100,
+        profit: 0.0, // Not positive
+        loss: -10.25
+      }, [new GraphQLError('Validation error: Profit must be greater than 0')]),
+      updateMockResponse('Product', {
+        id: 'product-id-positive-loss',
+        price: 99.99,
+        rating: 4.5,
+        stock: 100,
+        profit: 25.50,
+        loss: 10.25 // Positive
+      }, [new GraphQLError('Validation error: Loss must be negative')]),
+    ];
+    
+    const { spy, generateClient } = mockedGenerateClient(mockResponses);
+    let client: ReturnType<typeof generateClient<Schema>>;
+    
+    beforeAll(async () => {
       const config = await buildAmplifyConfig(schema);
       Amplify.configure(config);
-      const { generateClient } = mockedGenerateClient([]);
-      const client = generateClient<ClientSchema<typeof schema>>();
-
-      console.log(client);
-      
-      // (Internally, you might inspect the schema introspection or use debug APIs)
-      // Here, assert that the "title" field includes the expected validation rules.
-      // For example, you can fetch the field definition and check the validation rules.
-      // const titleValidations = client.schema.models.Post.fields.title.validation;
-      // expect(titleValidations).toEqual([
-      //   { type: 'minLength', value: 5, errorMessage: 'Title must be at least 5 characters' },
-      //   { type: 'maxLength', value: 100, errorMessage: 'Title must be at most 100 characters' },
-      //   { type: 'startsWith', value: 'post-', errorMessage: 'Title must start with post-' }
-      // ]);
+      client = generateClient<Schema>();
     });
-  });
-
-  // describe('Numeric Field Validations', () => {
-  //   test('accumulates numeric validators correctly', async () => {
-  //     // Build a schema with a model that uses numeric validations.
-  //     const schema = a.schema({
-  //       Product: a.model({
-  //         price: a.integer().default(10).validate(v => 
-  //           v.positive('Price must be positive')
-  //            .lt(1000, 'Price must be less than 1000')
-  //            .gte(0, 'Price must be non-negative')
-  //         ),
-  //       }),
-  //     });
-      
-  //     const config = await buildAmplifyConfig(schema);
-  //     Amplify.configure(config);
-  //     const { generateClient } = mockedGenerateClient([]);
-  //     const client = generateClient<ClientSchema<typeof schema>>();
-
-  //     // Check that the "price" field has the expected numeric validation rules.
-  //     const priceValidations = client.schema.models.Product.fields.price.validation;
-  //     expect(priceValidations).toEqual([
-  //       { type: 'gt', value: 0, errorMessage: 'Price must be positive' },
-  //       { type: 'lt', value: 1000, errorMessage: 'Price must be less than 1000' },
-  //       { type: 'gte', value: 0, errorMessage: 'Price must be non-negative' },
-  //     ]);
-  //   });
-  // });
-
-  describe('Validation Ordering & Duplication', () => {
-    test('validate() must come after default() and disallows duplicate validators', () => {
-      // The following examples are meant to be compile-time checks.
-      // They would be annotated with @ts-expect-error to indicate expected TS errors.
-      
-      // @ts-expect-error: validate() before default() is not allowed.
-      a.string().validate(v => v.minLength(5)).default('test');
-      
-      // @ts-expect-error: Duplicate validator (minLength) is disallowed.
-      a.string().validate(v => v.minLength(5).minLength(10));
-
-      // If you try to mix numeric validators on a string field, it should error.
-      // @ts-expect-error
-      a.string().validate(v => v.gt(10));
+    
+    const testValidCreate = async (modelName: string, data: any) => {
+      await (client.models as any)[modelName].create(data);
+      expectVariables(spy, { input: data });
+    };
+    
+    const testValidUpdate = async (modelName: string, data: any) => {
+      await (client.models as any)[modelName].update(data);
+      expectVariables(spy, { input: data });
+    };
+    
+    const testInvalidOperation = async (operation: 'create' | 'update', modelName: string, data: any, errorMessage: string) => {
+      await (client.models as any)[modelName][operation](data)
+        .catch((error: any) => {
+          expect(error.message).toContain(errorMessage);
+        });
+    };
+    
+    //===========================================
+    // POST MODEL TESTS
+    //===========================================
+    describe('Post Model Validation', () => {
+      describe('Create and Update Operations', () => {
+        it('should successfully create a Post with valid fields', async () => {
+          await testValidCreate('Post', {
+            title: 'Valid title',
+            slug: 'valid-slug-123',
+            summary: 'A valid summary',
+            content: 'This is valid content that is longer than 20 characters.'
+          });
+        });
+        
+        it('should successfully update a Post with valid fields', async () => {
+          await testValidUpdate('Post', {
+            id: 'post-id-1',
+            title: 'Updated title',
+            slug: 'updated-slug-123',
+            summary: 'An updated summary',
+            content: 'This is updated content that is longer than 20 characters.'
+          });
+        });
+        
+        it('should reject a Post with title too short', async () => {
+          await testInvalidOperation('create', 'Post', {
+            title: 'Hi', // Too short
+            slug: 'valid-slug',
+            summary: 'Summary',
+            content: 'Long enough content here'
+          }, 'Title must be at least 5 characters');
+        });
+        
+        it('should reject a Post update with invalid slug pattern', async () => {
+          await testInvalidOperation('update', 'Post', {
+            id: 'post-id-invalid-slug',
+            title: 'Valid title',
+            slug: 'INVALID_SLUG', // Invalid pattern
+            summary: 'Summary',
+            content: 'Long enough content here'
+          }, 'Slug must contain only lowercase letters, numbers, and hyphens');
+        });
+        
+        it('should reject a Post with summary too long', async () => {
+          await testInvalidOperation('create', 'Post', {
+            title: 'Valid title',
+            slug: 'valid-slug',
+            summary: 'A'.repeat(501), // Too long
+            content: 'Long enough content here'
+          }, 'Summary must be at most 500 characters');
+        });
+        
+        it('should reject a Post update with content too short', async () => {
+          await testInvalidOperation('update', 'Post', {
+            id: 'post-id-short-content',
+            title: 'Valid title',
+            slug: 'valid-slug',
+            summary: 'Summary',
+            content: 'Too short' // Too short
+          }, 'Content must be at least 20 characters');
+        });
+      });
+    });
+    
+    //===========================================
+    // COUPON MODEL TESTS
+    //===========================================
+    describe('Coupon Model Validation', () => {
+      describe('Create and Update Operations', () => {
+        it('should successfully create a Coupon with valid code', async () => {
+          await testValidCreate('Coupon', {
+            code: 'CPN-SUMMER-2025'
+          });
+        });
+        
+        it('should successfully update a Coupon with valid code', async () => {
+          await testValidUpdate('Coupon', {
+            id: 'coupon-id-1',
+            code: 'CPN-WINTER-2025'
+          });
+        });
+        
+        it('should reject a Coupon with invalid prefix', async () => {
+          await testInvalidOperation('create', 'Coupon', {
+            code: 'COUPON-SUMMER-2025' // Wrong prefix
+          }, 'Code must start with CPN-');
+        });
+        
+        it('should reject a Coupon update with invalid suffix', async () => {
+          await testInvalidOperation('update', 'Coupon', {
+            id: 'coupon-id-wrong-suffix',
+            code: 'CPN-SUMMER-2024' // Wrong suffix
+          }, 'Code must end with -2025');
+        });
+      });
+    });
+    
+    //===========================================
+    // PRODUCT MODEL TESTS
+    //===========================================
+    describe('Product Model Validation', () => {
+      describe('Create and Update Operations', () => {
+        it('should successfully create a Product with valid fields', async () => {
+          await testValidCreate('Product', {
+            price: 99.99,
+            rating: 4.5,
+            stock: 100,
+            profit: 25.50,
+            loss: -10.25
+          });
+        });
+        
+        it('should successfully update a Product with valid fields', async () => {
+          await testValidUpdate('Product', {
+            id: 'product-id-1',
+            price: 129.99,
+            rating: 4.8,
+            stock: 75,
+            profit: 35.50,
+            loss: -5.25
+          });
+        });
+        
+        it('should reject a Product update with negative price', async () => {
+          await testInvalidOperation('update', 'Product', {
+            id: 'product-id-negative-price',
+            price: -10.00, // Negative
+            rating: 4.5,
+            stock: 100,
+            profit: 25.50,
+            loss: -10.25
+          }, 'Price must be positive');
+        });
+        
+        it('should reject a Product with price too high', async () => {
+          await testInvalidOperation('create', 'Product', {
+            price: 15000.00, // Too high
+            rating: 4.5,
+            stock: 100,
+            profit: 25.50,
+            loss: -10.25
+          }, 'Price must be less than 10000');
+        });
+        
+        it('should reject a Product update with negative rating', async () => {
+          await testInvalidOperation('update', 'Product', {
+            id: 'product-id-negative-rating',
+            price: 99.99,
+            rating: -1.0, // Below minimum
+            stock: 100,
+            profit: 25.50,
+            loss: -10.25
+          }, 'Rating must be at least 0');
+        });
+        
+        it('should reject a Product with rating too high', async () => {
+          await testInvalidOperation('create', 'Product', {
+            price: 99.99,
+            rating: 6.0, // Above maximum
+            stock: 100,
+            profit: 25.50,
+            loss: -10.25
+          }, 'Rating must be at most 5');
+        });
+        
+        it('should reject a Product update with negative stock', async () => {
+          await testInvalidOperation('update', 'Product', {
+            id: 'product-id-negative-stock',
+            price: 99.99,
+            rating: 4.5,
+            stock: -10, // Negative
+            profit: 25.50,
+            loss: -10.25
+          }, 'Stock must be at least 0');
+        });
+        
+        it('should reject a Product with stock too high', async () => {
+          await testInvalidOperation('create', 'Product', {
+            price: 99.99,
+            rating: 4.5,
+            stock: 1500, // Too high
+            profit: 25.50,
+            loss: -10.25
+          }, 'Stock must be at most 1000');
+        });
+        
+        it('should reject a Product with zero profit', async () => {
+          await testInvalidOperation('create', 'Product', {
+            price: 99.99,
+            rating: 4.5,
+            stock: 100,
+            profit: 0.0, // Not positive
+            loss: -10.25
+          }, 'Profit must be greater than 0');
+        });
+        
+        it('should reject a Product update with positive loss', async () => {
+          await testInvalidOperation('update', 'Product', {
+            id: 'product-id-positive-loss',
+            price: 99.99,
+            rating: 4.5,
+            stock: 100,
+            profit: 25.50,
+            loss: 10.25 // Positive
+          }, 'Loss must be negative');
+        });
+      });
     });
   });
 });

--- a/packages/integration-tests/__tests__/defined-behavior/2-expected-use/validate-builder.ts
+++ b/packages/integration-tests/__tests__/defined-behavior/2-expected-use/validate-builder.ts
@@ -1,0 +1,87 @@
+import { a, ClientSchema } from '@aws-amplify/data-schema';
+import { Amplify } from 'aws-amplify';
+import { buildAmplifyConfig, mockedGenerateClient } from '../../utils';
+
+describe('Validate Builder', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('String Field Validations', () => {
+    test('accumulates string validators correctly', async () => {
+      // Build a schema with a model that uses multiple string validations.
+      const schema = a.schema({
+        Post: a.model({
+          title: a.string().validate(v => 
+            v.minLength(5, 'Title must be at least 5 characters')
+             .maxLength(100, 'Title must be at most 100 characters')
+             .startsWith('post-', 'Title must start with post-')
+          ),
+        }).authorization((allow) => allow.publicApiKey()),
+      });
+      
+      // Build config, configure Amplify, and generate the client.
+      const config = await buildAmplifyConfig(schema);
+      Amplify.configure(config);
+      const { generateClient } = mockedGenerateClient([]);
+      const client = generateClient<ClientSchema<typeof schema>>();
+
+      console.log(client);
+      
+      // (Internally, you might inspect the schema introspection or use debug APIs)
+      // Here, assert that the "title" field includes the expected validation rules.
+      // For example, you can fetch the field definition and check the validation rules.
+      // const titleValidations = client.schema.models.Post.fields.title.validation;
+      // expect(titleValidations).toEqual([
+      //   { type: 'minLength', value: 5, errorMessage: 'Title must be at least 5 characters' },
+      //   { type: 'maxLength', value: 100, errorMessage: 'Title must be at most 100 characters' },
+      //   { type: 'startsWith', value: 'post-', errorMessage: 'Title must start with post-' }
+      // ]);
+    });
+  });
+
+  // describe('Numeric Field Validations', () => {
+  //   test('accumulates numeric validators correctly', async () => {
+  //     // Build a schema with a model that uses numeric validations.
+  //     const schema = a.schema({
+  //       Product: a.model({
+  //         price: a.integer().default(10).validate(v => 
+  //           v.positive('Price must be positive')
+  //            .lt(1000, 'Price must be less than 1000')
+  //            .gte(0, 'Price must be non-negative')
+  //         ),
+  //       }),
+  //     });
+      
+  //     const config = await buildAmplifyConfig(schema);
+  //     Amplify.configure(config);
+  //     const { generateClient } = mockedGenerateClient([]);
+  //     const client = generateClient<ClientSchema<typeof schema>>();
+
+  //     // Check that the "price" field has the expected numeric validation rules.
+  //     const priceValidations = client.schema.models.Product.fields.price.validation;
+  //     expect(priceValidations).toEqual([
+  //       { type: 'gt', value: 0, errorMessage: 'Price must be positive' },
+  //       { type: 'lt', value: 1000, errorMessage: 'Price must be less than 1000' },
+  //       { type: 'gte', value: 0, errorMessage: 'Price must be non-negative' },
+  //     ]);
+  //   });
+  // });
+
+  describe('Validation Ordering & Duplication', () => {
+    test('validate() must come after default() and disallows duplicate validators', () => {
+      // The following examples are meant to be compile-time checks.
+      // They would be annotated with @ts-expect-error to indicate expected TS errors.
+      
+      // @ts-expect-error: validate() before default() is not allowed.
+      a.string().validate(v => v.minLength(5)).default('test');
+      
+      // @ts-expect-error: Duplicate validator (minLength) is disallowed.
+      a.string().validate(v => v.minLength(5).minLength(10));
+
+      // If you try to mix numeric validators on a string field, it should error.
+      // @ts-expect-error
+      a.string().validate(v => v.gt(10));
+    });
+  });
+});


### PR DESCRIPTION
## Changes

Changes to validate builder:
- Added schema generation logic
- Improve validate callback typing to disallow non-immediate duplicate validator e.g. `a.integer().validate(v => v.gt(0).lt(10).gt(0));` which was previously allowed

## Validation

- Updated existing tests to disallow non-immediate duplicate validator e.g. `a.integer().validate(v => v.gt(0).lt(10).gt(0));`
- Added snapshot tests
- Added defined behavior tests
- Tested the package locally and validation works as expected

## Checklist

- [ ] If this PR includes a functional change to the runtime or type-level behavior of the code, I have added or updated automated test coverage for this change. (see [Testing Strategy README](../TESTING-STRATEGY.md))
- [ ] If this PR requires a docs update, I have linked to that docs PR above.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
