### PR TITLE
fix: Multiple custom operation group auth definition of custom type

### DIFF
--- a/.changeset/six-cats-make.md
+++ b/.changeset/six-cats-make.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/data-schema': patch
+---
+
+Fix custom type authorization rule bug

--- a/packages/data-schema/__tests__/ModelType.test.ts
+++ b/packages/data-schema/__tests__/ModelType.test.ts
@@ -198,6 +198,39 @@ describe('model auth rules', () => {
     expect(graphql).toMatchSnapshot();
   });
 
+  it(`can merge group authorization to allow groups to be defined by multiple custom operations`, () => {
+    const schema = a.schema({
+      CustomType: a.customType({
+        id: a.string().required(),
+        name: a.string().required(),
+      }),
+      exampleAdminAndUserQuery: a
+        .query()
+        .arguments({
+          arg1: a.string().required(),
+        })
+        .returns(a.ref("CustomType").required().array().required())
+        .handler(a.handler.function('exampleFunc'))
+        .authorization((allow) => [allow.groups(["Admin", "User"])]),
+      exampleAdminOnlyQuery: a
+        .query()
+        .arguments({
+          arg1: a.string().required(),
+        })
+        .returns(a.ref("CustomType").required().array().required())
+        .handler(a.handler.function('exampleFunc'))
+        .authorization((allow) => [allow.groups(["Admin"])]),
+      ExampleModel: a.model({
+        name: a.ref("CustomType").required().array().required().authorization((allow) => [allow.groups(["Admin3", "User3"])]),
+        description: a.string().authorization((allow) => [allow.groups(["Admin3"])]),
+      })
+      .authorization((allow) => [allow.groups(["Admin2", "User2"])])
+    });
+
+    const graphql = schema.transform().schema;
+    expect(graphql).toMatchSnapshot();
+  });
+
   it(`can create a "multiple owners" rule on an implied (auto-created) field`, () => {
     const schema = a.schema({
       widget: a

--- a/packages/data-schema/__tests__/__snapshots__/ModelType.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/ModelType.test.ts.snap
@@ -523,7 +523,7 @@ exports[`model auth rules can merge group authorization to allow groups to be de
   description: String @auth(rules: [{allow: groups, groups: ["Admin3"]}])
 }
 
-type CustomType @aws_cognito_user_pools(cognito_groups: ["Admin", "User"]) @aws_cognito_user_pools(cognito_groups: ["Admin"])
+type CustomType @aws_cognito_user_pools(cognito_groups: ["Admin", "User"])
 {
   id: String!
   name: String!

--- a/packages/data-schema/__tests__/__snapshots__/ModelType.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/ModelType.test.ts.snap
@@ -516,6 +516,25 @@ exports[`model auth rules can define public auth with no provider 1`] = `
 }"
 `;
 
+exports[`model auth rules can merge group authorization to allow groups to be defined by multiple custom operations 1`] = `
+"type ExampleModel @model @auth(rules: [{allow: groups, groups: ["Admin2", "User2"]}])
+{
+  name: [CustomType!]! @auth(rules: [{allow: groups, groups: ["Admin3", "User3"]}])
+  description: String @auth(rules: [{allow: groups, groups: ["Admin3"]}])
+}
+
+type CustomType @aws_cognito_user_pools(cognito_groups: ["Admin", "User"]) @aws_cognito_user_pools(cognito_groups: ["Admin"])
+{
+  id: String!
+  name: String!
+}
+
+type Query {
+  exampleAdminAndUserQuery(arg1: String!): [CustomType!]! @function(name: "exampleFunc") @auth(rules: [{allow: groups, groups: ["Admin", "User"]}])
+  exampleAdminOnlyQuery(arg1: String!): [CustomType!]! @function(name: "exampleFunc") @auth(rules: [{allow: groups, groups: ["Admin"]}])
+}"
+`;
+
 exports[`model auth rules can specify an owner identityClaim 1`] = `
 "type widget @model @auth(rules: [{allow: owner, ownerField: "owner", identityClaim: "user_id"}])
 {

--- a/packages/data-schema/src/SchemaProcessor.ts
+++ b/packages/data-schema/src/SchemaProcessor.ts
@@ -916,7 +916,7 @@ function mapToNativeAppSyncAuthDirectives(
 
     groupProvider.forEach((groups, provider) => {
       rules.add(
-        `${provider}(cognito_groups: [${Array.from(groups.keys())
+        `${provider}(cognito_groups: [${Array.from(groups)
           .map((group) => `"${group}"`)
           .join(', ')}])`,
       );

--- a/packages/data-schema/src/SchemaProcessor.ts
+++ b/packages/data-schema/src/SchemaProcessor.ts
@@ -896,6 +896,8 @@ function mapToNativeAppSyncAuthDirectives(
 ) {
   const rules = new Set<string>();
 
+  const groupProvider: Map<string, Set<string>> = new Map();
+
   for (const entry of authorization) {
     const rule = accessData(entry);
 
@@ -904,16 +906,24 @@ function mapToNativeAppSyncAuthDirectives(
     const provider = getAppSyncAuthDirectiveFromRule(rule);
 
     if (rule.groups) {
-      // example: (cognito_groups: ["Bloggers", "Readers"])
-      rules.add(
-        `${provider}(cognito_groups: [${rule.groups
-          .map((group) => `"${group}"`)
-          .join(', ')}])`,
-      );
+      if(!groupProvider.has(provider)) {
+        groupProvider.set(provider, new Set());
+      };
+      rule.groups.forEach((group) => groupProvider.get(provider)?.add(group));
     } else {
       rules.add(provider);
     }
+
+    groupProvider.forEach((groups, provider) => {
+      rules.add(
+        `${provider}(cognito_groups: [${Array.from(groups.keys())
+          .map((group) => `"${group}"`)
+          .join(', ')}])`,
+      );
+      // example: (cognito_groups: ["Bloggers", "Readers"])
+    })
   }
+
 
   const authString = [...rules].join(' ');
 


### PR DESCRIPTION
## Problem
When more than one custom operation make reference to a single custom type, the type has the group auth directive applied multiple times.  

It doesn't seem necessary to have auth directives on custom types, but I am unsure what the impact of removing them would be and if there is an impact / effect to having auth directives then removing them would be breaking.  Based on this, the most direct fix is to merge group auth directives before they are added to any types. Since duplicate directives are always broken this change will not impact/change the behavior for existing functioning applications.

**Issue number, if available:**
- https://github.com/aws-amplify/amplify-data/issues/495

## Changes
- Merge group auth directives before adding the rules to an entity in the graphql schema

## Validation
- Added a unit test (see [the first commit with the test producing the issue diffed against the second commit applying the fix](https://github.com/aws-amplify/amplify-data/pull/572/commits/bf707db0439679e3910c3657de4df316ffb7c2db))
- Applied this change in the example app from the issue to confirm it builds

## Checklist
- [x] If this PR includes a functional change to the runtime or type-level behavior of the code, I have added or updated automated test coverage for this change. (see [Testing Strategy README](../TESTING-STRATEGY.md))

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
