### PR TITLE
fix: Recursive custom type error

### DIFF
--- a/.changeset/six-carrots-press.md
+++ b/.changeset/six-carrots-press.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/data-schema': patch
+---
+
+Fix recursive custom type error

--- a/packages/data-schema/__tests__/CustomType.test.ts
+++ b/packages/data-schema/__tests__/CustomType.test.ts
@@ -258,4 +258,32 @@ describe('CustomType transform', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  test('Indirect recursive CustomTypes transform when used by both models and operations', () => {
+    const s = a
+      .schema({
+        Post: a.model({
+          meta: a.customType({
+            status: a.enum(['unpublished', 'published']),
+            recursiveCustomType: a.ref('CustTypeA'),
+          }),
+        }),
+        getLikedPost: a
+          .query()
+          .returns(a.ref('CustTypeA').array())
+          .handler(a.handler.function('myFunc')),
+        CustTypeA: a.customType({
+          company: a.ref('CustTypeB'),
+        }),
+        CustTypeB: a.customType({
+          tenants: a.ref('CustTypeA').array(),
+        }),
+      })
+      .authorization((allow) => allow.publicApiKey());
+
+    const result = s.transform().schema;
+
+    expect(result).toMatchSnapshot();
+  });
+
 });

--- a/packages/data-schema/__tests__/__snapshots__/CustomType.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/CustomType.test.ts.snap
@@ -215,3 +215,35 @@ enum PostMetaStatus {
   published
 }"
 `;
+
+exports[`CustomType transform Indirect recursive CustomTypes transform when used by both models and operations 1`] = `
+"type Post @model @auth(rules: [{allow: public, provider: apiKey}])
+{
+  meta: PostMeta
+}
+
+type CustTypeA @aws_api_key
+{
+  company: CustTypeB
+}
+
+type CustTypeB @aws_api_key
+{
+  tenants: [CustTypeA]
+}
+
+type PostMeta 
+{
+  status: PostMetaStatus
+  recursiveCustomType: CustTypeA
+}
+
+enum PostMetaStatus {
+  unpublished
+  published
+}
+
+type Query {
+  getLikedPost: [CustTypeA] @function(name: "myFunc") @auth(rules: [{allow: public, provider: apiKey}])
+}"
+`;

--- a/packages/data-schema/src/SchemaProcessor.ts
+++ b/packages/data-schema/src/SchemaProcessor.ts
@@ -2246,12 +2246,14 @@ function extractNestedCustomTypeNames(
     for (const [fieldName, fieldDef] of Object.entries(fields)) {
       if (isCustomType(fieldDef)) {
         const customTypeName = `${capitalize(name)}${capitalize(fieldName)}`;
-        namesList.push(customTypeName);
-        traverseCustomTypeFields(customTypeName, fieldDef, namesList);
+        if (!namesList.includes(customTypeName)){
+          namesList.push(customTypeName);
+          traverseCustomTypeFields(customTypeName, fieldDef, namesList);
+        }
       } else if (isRefField(fieldDef)) {
         const refType = getRefType(fieldDef.data.link, name);
 
-        if (refType.type === 'CustomType') {
+        if (refType.type === 'CustomType' && !namesList.includes(fieldDef.data.link)) {
           namesList.push(fieldDef.data.link);
           traverseCustomTypeFields(fieldDef.data.link, refType.def, namesList);
         }


### PR DESCRIPTION
## Problem
When a recursive custom type is used in a custom operation it fails to transform due to infinite recursion.

**Issue number, if available:**
https://github.com/aws-amplify/amplify-data/issues/423

## Changes
While recursively discovering custom types, this change short circuits when a custom type has been seen/listed already.

## Validation
Test added that reproduces the error, which this change fixes.

## Checklist
- [ ] If this PR includes a functional change to the runtime or type-level behavior of the code, I have added or updated automated test coverage for this change. (see [Testing Strategy README](../TESTING-STRATEGY.md))
- [ ] If this PR requires a docs update, I have linked to that docs PR above.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
