### PR TITLE
chore: add claude models 3.7 and 4

### DIFF
--- a/.changeset/twenty-foxes-own.md
+++ b/.changeset/twenty-foxes-own.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/data-schema': patch
+---
+
+chore: add claude models 3.7 and 4

--- a/packages/data-schema/src/ai/ModelType.ts
+++ b/packages/data-schema/src/ai/ModelType.ts
@@ -15,6 +15,9 @@ const supportedModelsLookup = {
   'Claude 3.5 Haiku': 'anthropic.claude-3-5-haiku-20241022-v1:0',
   'Claude 3.5 Sonnet': 'anthropic.claude-3-5-sonnet-20240620-v1:0',
   'Claude 3.5 Sonnet v2': 'anthropic.claude-3-5-sonnet-20241022-v2:0',
+  'Claude 3.7 Sonnet': 'anthropic.claude-3-7-sonnet-20250219-v1:0',
+  'Claude Opus 4': 'anthropic.claude-opus-4-20250514-v1:0',
+  'Claude Sonnet 4': 'anthropic.claude-sonnet-4-20250514-v1:0',
   // Cohere models
   'Cohere Command R': 'cohere.command-r-v1:0',
   'Cohere Command R+': 'cohere.command-r-plus-v1:0',


### PR DESCRIPTION
## Problem

We were missing the models in the list. I added them following this PR: https://github.com/aws-amplify/amplify-data/pull/397


**Issue number, if available:** https://github.com/aws-amplify/amplify-data/issues/549

## Changes

Adds Claude 3.7 Sonnet, Claude Opus 4 and Claude Sonnet 4.

**Corresponding docs PR, if applicable:**

## Validation

## Checklist

- [ ] If this PR includes a functional change to the runtime or type-level behavior of the code, I have added or updated automated test coverage for this change. (see [Testing Strategy README](../TESTING-STRATEGY.md))
- [ ] If this PR requires a docs update, I have linked to that docs PR above.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
