### PR TITLE
fix: schema processor to preserve array type for custom types

### DIFF
--- a/.changeset/happy-apes-count.md
+++ b/.changeset/happy-apes-count.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/data-schema': minor
+---
+
+fix: array fields within custom types lose their array structure when generating input types

--- a/packages/data-schema/__tests__/ModelSchema.test.ts
+++ b/packages/data-schema/__tests__/ModelSchema.test.ts
@@ -408,4 +408,110 @@ describe('custom operation argument inputs', () => {
     expect(schema.transform().schema).toMatchSnapshot();
   });
 
-})
+});
+
+describe('nested array fields in custom types', () => {
+
+  it('when a custom type has an array ref field the input type preserves the array', () => {
+    const fn1 = defineFunctionStub({});
+
+    const schema = a
+      .schema({
+        testType: a.customType({
+          testField: a.string().required(),
+        }),
+
+        containerType: a.customType({
+          items: a.ref('testType').array(),
+        }),
+
+        testMutation: a
+          .mutation()
+          .arguments({
+            container: a.ref('containerType'),
+          })
+          .returns(a.string())
+          .handler(a.handler.function(fn1))
+      })
+      .authorization((allow) => allow.owner());
+
+    expect(schema.transform().schema).toMatchSnapshot();
+  });
+
+  it('when a custom type has a required array ref field the input type is a required array', () => {
+    const fn1 = defineFunctionStub({});
+
+    const schema = a
+      .schema({
+        testType: a.customType({
+          testField: a.string().required(),
+        }),
+
+        containerType: a.customType({
+          items: a.ref('testType').array().required(),
+        }),
+
+        testMutation: a
+          .mutation()
+          .arguments({
+            container: a.ref('containerType'),
+          })
+          .returns(a.string())
+          .handler(a.handler.function(fn1))
+      })
+      .authorization((allow) => allow.owner());
+
+    expect(schema.transform().schema).toMatchSnapshot();
+  });
+
+  it('when a custom type has an array of required ref fields the input type is an array of required refs', () => {
+    const fn1 = defineFunctionStub({});
+
+    const schema = a
+      .schema({
+        testType: a.customType({
+          testField: a.string().required(),
+        }),
+
+        containerType: a.customType({
+          items: a.ref('testType').required().array(),
+        }),
+
+        testMutation: a
+          .mutation()
+          .arguments({
+            container: a.ref('containerType'),
+          })
+          .returns(a.string())
+          .handler(a.handler.function(fn1))
+      })
+      .authorization((allow) => allow.owner());
+
+    expect(schema.transform().schema).toMatchSnapshot();
+  });
+
+  it('when a custom type has an array enum ref field the input type preserves the array', () => {
+    const fn1 = defineFunctionStub({});
+
+    const schema = a
+      .schema({
+        testEnum: a.enum(['VALUE1', 'VALUE2']),
+
+        containerType: a.customType({
+          statuses: a.ref('testEnum').array(),
+        }),
+
+        testMutation: a
+          .mutation()
+          .arguments({
+            container: a.ref('containerType'),
+          })
+          .returns(a.string())
+          .handler(a.handler.function(fn1))
+      })
+      .authorization((allow) => allow.owner());
+
+    expect(schema.transform().schema).toMatchSnapshot();
+  });
+
+});

--- a/packages/data-schema/__tests__/__snapshots__/ModelSchema.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/ModelSchema.test.ts.snap
@@ -167,3 +167,95 @@ exports[`empty model auth inherits global auth 1`] = `
   someOwnerField: String
 }"
 `;
+
+exports[`nested array fields in custom types when a custom type has a required array ref field the input type is a required array 1`] = `
+"type testType 
+{
+  testField: String!
+}
+
+type containerType 
+{
+  items: [testType]!
+}
+
+input testTypeInput {
+  testField: String!
+}
+
+input containerTypeInput {
+  items: [testTypeInput]!
+}
+
+type Mutation {
+  testMutation(container: containerTypeInput): String @function(name: "FnTestMutation") @auth(rules: [{allow: owner, ownerField: "owner"}])
+}"
+`;
+
+exports[`nested array fields in custom types when a custom type has an array enum ref field the input type preserves the array 1`] = `
+"enum testEnum {
+  VALUE1
+  VALUE2
+}
+
+type containerType 
+{
+  statuses: [testEnum]
+}
+
+input containerTypeInput {
+  statuses: [testEnum]
+}
+
+type Mutation {
+  testMutation(container: containerTypeInput): String @function(name: "FnTestMutation") @auth(rules: [{allow: owner, ownerField: "owner"}])
+}"
+`;
+
+exports[`nested array fields in custom types when a custom type has an array of required ref fields the input type is an array of required refs 1`] = `
+"type testType 
+{
+  testField: String!
+}
+
+type containerType 
+{
+  items: [testType!]
+}
+
+input testTypeInput {
+  testField: String!
+}
+
+input containerTypeInput {
+  items: [testTypeInput!]
+}
+
+type Mutation {
+  testMutation(container: containerTypeInput): String @function(name: "FnTestMutation") @auth(rules: [{allow: owner, ownerField: "owner"}])
+}"
+`;
+
+exports[`nested array fields in custom types when a custom type has an array ref field the input type preserves the array 1`] = `
+"type testType 
+{
+  testField: String!
+}
+
+type containerType 
+{
+  items: [testType]
+}
+
+input testTypeInput {
+  testField: String!
+}
+
+input containerTypeInput {
+  items: [testTypeInput]
+}
+
+type Mutation {
+  testMutation(container: containerTypeInput): String @function(name: "FnTestMutation") @auth(rules: [{allow: owner, ownerField: "owner"}])
+}"
+`;

--- a/packages/data-schema/src/SchemaProcessor.ts
+++ b/packages/data-schema/src/SchemaProcessor.ts
@@ -1391,7 +1391,13 @@ function generateInputTypes(
         if (refType.type === 'CustomType') {
           const nestedInputTypeName = `${fieldDef.data.link}Input`;
           processedFields[fieldName] = {
-            data: { type: 'ref', link: nestedInputTypeName },
+            data: { 
+              type: 'ref', 
+              link: nestedInputTypeName,
+              array: fieldDef.data.array,
+              arrayRequired: fieldDef.data.arrayRequired,
+              valueRequired: fieldDef.data.valueRequired
+            },
           };
 
           // Process the nested type if it hasn't been processed and isn't a circular reference
@@ -1413,7 +1419,13 @@ function generateInputTypes(
           }
         } else if (refType.type === 'Enum') {
           processedFields[fieldName] = {
-            data: { type: 'ref', link: fieldDef.data.link },
+            data: { 
+              type: 'ref', 
+              link: fieldDef.data.link,
+              array: fieldDef.data.array,
+              arrayRequired: fieldDef.data.arrayRequired,
+              valueRequired: fieldDef.data.valueRequired
+            },
           };
         } else {
           throw new Error(
@@ -1425,7 +1437,10 @@ function generateInputTypes(
         // Handle inline custom types
         const nestedInputTypeName = `${capitalize(originalTypeName)}${capitalize(fieldName)}Input`;
         processedFields[fieldName] = {
-          data: { type: 'ref', link: nestedInputTypeName },
+          data: { 
+            type: 'ref', 
+            link: nestedInputTypeName
+          },
         };
 
         if (!processedTypes.has(nestedInputTypeName)) {


### PR DESCRIPTION
## Problem

Fixes array handling in custom types when using `a.ref()` to reference types containing `a.ref().array()`. Previously, arrays were treated as single items in GraphQL schema generation, causing "Variable has an invalid value" errors during mutations.

When referencing custom types or enums with array modifiers through `a.ref()`, the array properties (`array`, `arrayRequired`, `valueRequired`) were not preserved in the generated input types, resulting in incorrect GraphQL schemas missing array brackets.

**Issue number, if available:**

## Changes

Updated `processNonScalarFields` method in `SchemaProcessor.ts` to preserve array properties for both CustomType and Enum references when generating input types. The fix ensures that array modifiers are correctly carried through to the final GraphQL schema.

Critical change: Modified the data object creation to include `array`, `arrayRequired`, and `valueRequired` properties from the original field definition, maintaining backward compatibility while fixing the array handling bug.

**Corresponding docs PR, if applicable:**

## Validation

• Added comprehensive unit tests covering array refs, required arrays, arrays of required elements, and enum arrays
• All existing tests continue to pass, ensuring backward compatibility
• Generated Jest snapshots verify correct GraphQL output: [Type], [Type]!, [Type!], [Status]
• Manual verification confirms GraphQL mutations now work correctly with nested array fields

## Checklist

- [x] If this PR includes a functional change to the runtime or type-level behavior of the code, I have added or updated automated test coverage for this change. (see [Testing Strategy README](../TESTING-STRATEGY.md))
- [ ] If this PR requires a docs update, I have linked to that docs PR above.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
