### PR TITLE
feat(auth): add inGroup() method for owner authorization

### DIFF
--- a/.changeset/easy-lizards-smile.md
+++ b/.changeset/easy-lizards-smile.md
@@ -1,0 +1,5 @@
+---
+"@aws-amplify/data-schema": minor
+---
+
+Add `inGroup()` method for owner authorization rules to require group membership alongside ownership

--- a/packages/data-schema/__tests__/__snapshots__/ModelField.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/ModelField.test.ts.snap
@@ -31,6 +31,7 @@ exports[`field level auth implied fields objects can be extracted 1`] = `
   },
   {
     "identityClaim": [Function],
+    "inGroup": [Function],
     Symbol(data): {
       "groupOrOwnerField": "admin",
       "groups": undefined,
@@ -46,6 +47,7 @@ exports[`field level auth implied fields objects can be extracted 1`] = `
     },
   },
   {
+    "inGroup": [Function],
     Symbol(data): {
       "groupOrOwnerField": "admin",
       "groups": undefined,
@@ -94,6 +96,7 @@ exports[`field level auth implied fields objects can be extracted from related m
   },
   {
     "identityClaim": [Function],
+    "inGroup": [Function],
     Symbol(data): {
       "groupOrOwnerField": "admin",
       "groups": undefined,
@@ -109,6 +112,7 @@ exports[`field level auth implied fields objects can be extracted from related m
     },
   },
   {
+    "inGroup": [Function],
     Symbol(data): {
       "groupOrOwnerField": "admin",
       "groups": undefined,

--- a/packages/data-schema/__tests__/__snapshots__/ModelType.test.ts.snap
+++ b/packages/data-schema/__tests__/__snapshots__/ModelType.test.ts.snap
@@ -628,6 +628,107 @@ type widget @model @auth(rules: [{allow: owner, ownerField: "owner"}])
 }"
 `;
 
+exports[`model auth rules owner.inGroup() - owner auth with required group membership can chain owner.inGroup() with identityClaim 1`] = `
+"type widget @model @auth(rules: [{allow: owner, ownerField: "owner", groups: ["AdminGroup"], identityClaim: "user_id"}])
+{
+  title: String!
+}"
+`;
+
+exports[`model auth rules owner.inGroup() - owner auth with required group membership can chain owner.inGroup() with operations 1`] = `
+"type widget @model @auth(rules: [{allow: owner, operations: [create, read, update], ownerField: "owner", groups: ["AdminGroup"]}])
+{
+  title: String!
+}"
+`;
+
+exports[`model auth rules owner.inGroup() - owner auth with required group membership can define owner auth with inGroup requirement 1`] = `
+"type widget @model @auth(rules: [{allow: owner, ownerField: "owner", groups: ["AdminGroup"]}])
+{
+  title: String!
+}"
+`;
+
+exports[`model auth rules owner.inGroup() - owner auth with required group membership can define owner auth with multiple inGroup requirements 1`] = `
+"type widget @model @auth(rules: [{allow: owner, ownerField: "owner", groups: ["AdminGroup", "SuperUserGroup"]}])
+{
+  title: String!
+}"
+`;
+
+exports[`model auth rules owner.inGroup() - owner auth with required group membership can define ownerDefinedIn with inGroup requirement 1`] = `
+"type widget @model @auth(rules: [{allow: owner, ownerField: "customOwnerField", groups: ["AdminGroup"]}])
+{
+  title: String!
+}"
+`;
+
+exports[`model auth rules owner.inGroup() - owner auth with required group membership can define ownersDefinedIn with inGroup requirement 1`] = `
+"type widget @model @auth(rules: [{allow: owner, ownerField: "editors", groups: ["EditorGroup"]}])
+{
+  title: String!
+}"
+`;
+
+exports[`model auth rules owner.inGroup() combined with group() - rules should not merge multiple owner rules with different inGroup requirements remain separate 1`] = `
+"type widget @model @auth(rules: [{allow: owner, operations: [create, read, update, delete], ownerField: "owner", groups: ["AdminGroup"]},
+  {allow: owner, operations: [read], ownerField: "reviewer", groups: ["ReviewerGroup"]}])
+{
+  title: String!
+}"
+`;
+
+exports[`model auth rules owner.inGroup() combined with group() - rules should not merge owner.inGroup() and group() with same group remain as separate rules 1`] = `
+"type widget @model @auth(rules: [{allow: owner, ownerField: "owner", groups: ["AdminGroup"]},
+  {allow: groups, groups: ["AdminGroup"]}])
+{
+  title: String!
+}"
+`;
+
+exports[`model auth rules owner.inGroup() combined with group() - rules should not merge owner.inGroup() and groups() with overlapping groups remain as separate rules 1`] = `
+"type widget @model @auth(rules: [{allow: owner, ownerField: "owner", groups: ["AdminGroup", "ModeratorGroup"]},
+  {allow: groups, groups: ["AdminGroup", "UserGroup"]}])
+{
+  title: String!
+}"
+`;
+
+exports[`model auth rules owner.inGroup() combined with group() - rules should not merge owner.inGroup() combined with group() and authenticated() produces correct output 1`] = `
+"type widget @model @auth(rules: [{allow: owner, ownerField: "owner", groups: ["AdminGroup"]},
+  {allow: groups, operations: [read], groups: ["AdminGroup"]},
+  {allow: private, operations: [read]}])
+{
+  title: String!
+}"
+`;
+
+exports[`model auth rules owner.inGroup() combined with group() - rules should not merge owner.inGroup() with different groups and different permissions remain separate 1`] = `
+"type widget @model @auth(rules: [{allow: owner, operations: [read], ownerField: "owner", groups: ["ReadersGroup"]},
+  {allow: owner, operations: [create, update, delete], ownerField: "owner", groups: ["WritersGroup"]}])
+{
+  title: String!
+}"
+`;
+
+exports[`model auth rules owner.inGroup() combined with group() - rules should not merge owner.inGroup() with overlapping groups but different permissions remain separate 1`] = `
+"type widget @model @auth(rules: [{allow: owner, operations: [read, update], ownerField: "owner", groups: ["AdminGroup", "ModeratorGroup"]},
+  {allow: owner, operations: [create, delete], ownerField: "owner", groups: ["AdminGroup", "SuperUserGroup"]}])
+{
+  title: String!
+}"
+`;
+
+exports[`model auth rules owner.inGroup() combined with group() - rules should not merge ownerDefinedIn.inGroup() with different groups and permissions on same field 1`] = `
+"type widget @model @auth(rules: [{allow: owner, operations: [read], ownerField: "createdBy", groups: ["ViewerGroup"]},
+  {allow: owner, operations: [read, update], ownerField: "createdBy", groups: ["EditorGroup"]},
+  {allow: owner, operations: [create, read, update, delete], ownerField: "createdBy", groups: ["AdminGroup"]}])
+{
+  title: String!
+  createdBy: String
+}"
+`;
+
 exports[`secondary indexes generates a primary key AND secondary index annotation with attributes 1`] = `
 "type widget @model @auth(rules: [{allow: public, provider: apiKey}])
 {

--- a/packages/data-schema/src/Authorization.ts
+++ b/packages/data-schema/src/Authorization.ts
@@ -172,6 +172,22 @@ function identityClaim<SELF extends Authorization<any, any, any>>(
   return omit(this, 'identityClaim');
 }
 
+/**
+ * Requires the owner to also be a member of one of the specified groups.
+ * This adds an additional group check to owner-based authorization.
+ *
+ * @param this Authorization object to operate against.
+ * @param groups One or more group names that the owner must belong to.
+ * @returns A copy of the Authorization object with the group requirement attached.
+ */
+function inGroup<SELF extends Authorization<any, any, any>>(
+  this: SELF,
+  ...groups: string[]
+) {
+  this[__data].groups = groups;
+  return omit(this, 'inGroup');
+}
+
 function withClaimIn<SELF extends Authorization<any, any, any>>(
   this: SELF,
   property: string,
@@ -296,6 +312,7 @@ export const allow = {
       {
         to,
         identityClaim,
+        inGroup,
       },
     );
   },
@@ -325,6 +342,7 @@ export const allow = {
       {
         to,
         identityClaim,
+        inGroup,
       },
     );
   },
@@ -359,6 +377,7 @@ export const allow = {
       {
         to,
         identityClaim,
+        inGroup,
       },
     );
   },

--- a/packages/data-schema/src/SchemaProcessor.ts
+++ b/packages/data-schema/src/SchemaProcessor.ts
@@ -802,6 +802,8 @@ function calculateAuth(authorization: Authorization<any, any, any>[]) {
       }
     }
 
+    // For group strategy, groups is a list of allowed groups
+    // For owner strategy with inGroup(), groups is a list of required groups (AND condition)
     if (rule.groups) {
       // does `group` need to be escaped?
       ruleParts.push(


### PR DESCRIPTION
## Problem

Currently, owner-based authorization and group-based authorization are separate strategies that work with OR logic. There's no way to require that a user must be both the owner AND a member of a specific group to access a resource (AND logic).

**Issue number, if available:** aws-amplify/amplify-category-api#3381

## Changes

Add `inGroup()` method to owner authorization rules that allows requiring group membership in addition to owner matching:

- Add `inGroup(...groups: string[])` method to `owner()`, `ownerDefinedIn()`, and `ownersDefinedIn()`
- Groups specified via `inGroup()` are passed to the transformer via the `groups` field on owner rules
- The transformer interprets `groups` on an owner rule as AND logic (must be owner AND in group)

Example usage:
```typescript
.authorization((allow) => allow.owner().inGroup('AdminGroup'))
```

**Corresponding docs PR, if applicable:** TBD

## Validation

- Added comprehensive unit tests for `inGroup()` with various combinations (552 tests passed)
- Snapshot tests verify correct GraphQL schema output with `groups` on owner rules
- Tests cover: single group, multiple groups, chaining with operations/identityClaim, different owner field definitions

## Checklist

- [x] If this PR includes a functional change to the runtime or type-level behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._