### PR TITLE
chore(deps): bump lodash from 4.17.21 to 4.17.23

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16512,9 +16512,9 @@
       "license": "ISC"
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.includes": {

--- a/package.json
+++ b/package.json
@@ -89,11 +89,13 @@
   "resolutions": {
     "cookie": "^0.7.2",
     "qs": "^6.14.1",
-    "@smithy/config-resolver": "^4.4.0"
+    "@smithy/config-resolver": "^4.4.0",
+    "lodash": "^4.17.23"
   },
   "overrides": {
     "cookie": "^0.7.2",
     "qs": "^6.14.1",
-    "@smithy/config-resolver": "^4.4.0"
+    "@smithy/config-resolver": "^4.4.0",
+    "lodash": "^4.17.23"
   }
 }


### PR DESCRIPTION
## Problem

https://github.com/aws-amplify/amplify-data/security/dependabot/68

**Issue number, if available:**

## Changes

Add resolution for lodash

**Corresponding docs PR, if applicable:**

## Validation

## Checklist

- [ ] If this PR includes a functional change to the runtime or type-level behavior of the code, I have added or updated automated test coverage for this change. (see [Testing Strategy README](../TESTING-STRATEGY.md))
- [ ] If this PR requires a docs update, I have linked to that docs PR above.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
