### PR TITLE
chore(deps): upgrade fast-xml-parser to 5.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2188,28 +2188,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.620.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.620.1.tgz",
@@ -13356,9 +13334,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.3.tgz",
-      "integrity": "sha512-RKihhV+SHsIUGXObeVy9AXiBbFwkVk7Syp8XgwN5U3JV416+Gwp/GO9i0JYKmikykgz/UHRrrV4ROuZEo/T0ig==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.6.tgz",
+      "integrity": "sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==",
       "funding": [
         {
           "type": "github",
@@ -13367,7 +13345,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.1.1"
+        "strnum": "^2.1.2"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -19492,9 +19470,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "cookie": "^0.7.2",
     "qs": "^6.15.0",
     "@smithy/config-resolver": "^4.4.0",
-    "lodash": "^4.17.23"
+    "lodash": "^4.17.23",
+    "fast-xml-parser": "^5.3.6"
   }
 }


### PR DESCRIPTION
## Problem

Fixes CVE-2026-26278 - DoS vulnerability in `fast-xml-parser` affecting versions < 5.3.6.

**Issue number, if available:** N/A

## Changes

Added `fast-xml-parser: ^5.3.6` to npm overrides in root `package.json` to force all transitive dependencies to use the patched version.

## Validation

- Verified all instances of `fast-xml-parser` are now at version 5.3.6 via `npm ls fast-xml-parser`
- Confirmed high severity vulnerabilities reduced from 21 to 0

## Checklist

- [ ] If this PR includes a functional change to the runtime or type-level behavior of the code, I have added or updated automated test coverage for this change.
- [ ] If this PR requires a docs update, I have linked to that docs PR above.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._