### PR TITLE
chore(deps): update overrides for immutable

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13715,13 +13715,10 @@
       }
     },
     "node_modules/immutable": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.7.6.tgz",
-      "integrity": "sha512-AizQPcaofEtO11RZhPPHBOJRdo/20MKQF9mBLnVkBoyHi1/zXK8fzVdnEpSV9gxqtnh6Qomfp3F0xT5qP/vThw==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.8.0"
-      }
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "@actions/github": "^6.0.0",
     "@aws-amplify/adapter-nextjs": "^1.7.1",
     "@aws-sdk/types": "^3.609.0",
-    "next": "^16.1.5",
     "@changesets/cli": "^2.29.8",
     "@microsoft/api-documenter": "^7.29.5",
     "@microsoft/api-extractor": "^7.57.5",
@@ -78,6 +77,7 @@
     "jest": "^29.7.0",
     "jest-tsd": "^0.2.2",
     "jsdom": "^25.0.0",
+    "next": "^16.1.5",
     "prettier": "^3.0.3",
     "rimraf": "^5.0.5",
     "ts-jest": "^29.4.6",
@@ -91,13 +91,15 @@
     "cookie": "^0.7.2",
     "qs": "^6.15.0",
     "@smithy/config-resolver": "^4.4.0",
-    "lodash": "^4.17.23"
+    "lodash": "^4.17.23",
+    "immutable": "^4.3.8"
   },
   "overrides": {
     "cookie": "^0.7.2",
     "qs": "^6.15.0",
     "@smithy/config-resolver": "^4.4.0",
     "lodash": "^4.17.23",
+    "immutable": "^4.3.8",
     "fast-xml-parser": "^5.3.6",
     "ajv": "8.18.0",
     "minimatch": ">=3.1.4",


### PR DESCRIPTION
## Summary

Addresses Dependabot alert #94 (high severity).

**Vulnerability:** Prototype Pollution in `immutable` < 4.3.8 (CVE-2026-29063)

**Root cause:** `immutable@~3.7.6` is a transitive dependency pulled in via:
```
integration-tests
  → @aws-amplify/graphql-generator@0.5.3
    → @aws-amplify/appsync-modelgen-plugin@2.15.2
      → @graphql-codegen/visitor-plugin-common@^1.22.0
        → @graphql-tools/relay-operation-optimizer@6.5.18
          → @ardatan/relay-compiler@12.0.0
            → immutable@~3.7.6
```

**Fix:** Added `immutable: "^4.3.8"` to `overrides` and `resolutions` in root `package.json` to force the patched version.

**Note:** This is a test-only dependency chain (`integration-tests` is private and never published). The long-term fix is for `@aws-amplify/appsync-modelgen-plugin` to bump `@graphql-codegen/visitor-plugin-common` from v1 to v5+, which uses `@ardatan/relay-compiler@^13` (depends on `immutable@^5.1.5`, not vulnerable). Once that upstream update ships, this override can be removed.

## Testing

- `npm run build` ✅
- `turbo run test` ✅ (550 tests pass)