### PR TITLE
chore: bump node from 20 to 24

### DIFF
--- a/.github/actions/load-verdaccio-with-amplify-data/action.yml
+++ b/.github/actions/load-verdaccio-with-amplify-data/action.yml
@@ -18,7 +18,7 @@ runs:
       shell: bash
       working-directory: ./amplify-data
     - name: Upload artifact
-      uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       if: failure()
       with:
         name: ${{ inputs.test_name }}-verdaccio-log

--- a/.github/actions/node-and-build/action.yml
+++ b/.github/actions/node-and-build/action.yml
@@ -10,16 +10,16 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Setup Node.js 20
-      uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.9 https://github.com/actions/setup-node/commit/1e60f620b9541d16bece96c5465dc8ee9832be0b
+    - name: Setup Node.js
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
-        node-version: 20
+        node-version: 24
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
     - name: Enable Corepack for Yarn 4
       run: corepack enable
       shell: bash
-    - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+    - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       id: cache-build-artifacts
       with:
         path: |

--- a/.github/actions/setup-samples-staging/action.yml
+++ b/.github/actions/setup-samples-staging/action.yml
@@ -10,7 +10,7 @@ runs:
   using: 'composite'
   steps:
     - name: Create cache
-      uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       id: cache-samples-staging-build
       with:
         key: aws-amplify-js-samples-staging-build-${{ github.sha }}
@@ -20,7 +20,7 @@ runs:
       env:
         SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
     - name: Checkout staging repo
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ github.repository_owner }}/amplify-js-samples-staging
         path: amplify-js-samples-staging

--- a/.github/workflows/callable-check-api.yml
+++ b/.github/workflows/callable-check-api.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Setup node and build the repository

--- a/.github/workflows/callable-check-changeset.yml
+++ b/.github/workflows/callable-check-changeset.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path:
             amplify-data

--- a/.github/workflows/callable-check-type-perf.yml
+++ b/.github/workflows/callable-check-type-perf.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Setup node and build the repository

--- a/.github/workflows/callable-dependency-review.yml
+++ b/.github/workflows/callable-dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 

--- a/.github/workflows/callable-e2e-test-detox.yml
+++ b/.github/workflows/callable-e2e-test-detox.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Setup node and build the repository

--- a/.github/workflows/callable-e2e-test.yml
+++ b/.github/workflows/callable-e2e-test.yml
@@ -55,7 +55,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Setup node and build the repository
@@ -129,7 +129,7 @@ jobs:
             yarn "$E2E_YARN_SCRIPT"
           fi
       - name: Upload artifact
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: failure()
         with:
           name: ${{ inputs.test_name }}

--- a/.github/workflows/callable-e2e-tests.yml
+++ b/.github/workflows/callable-e2e-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Read integ config files

--- a/.github/workflows/callable-local-e2e-test.yml
+++ b/.github/workflows/callable-local-e2e-test.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Setup node and build the repository

--- a/.github/workflows/callable-local-e2e-tests.yml
+++ b/.github/workflows/callable-local-e2e-tests.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Setup node and build the repository
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Read integ config files

--- a/.github/workflows/callable-prebuild-amplify-data.yml
+++ b/.github/workflows/callable-prebuild-amplify-data.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ inputs.runs_on }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Setup node and build the repository

--- a/.github/workflows/callable-prebuild-samples-staging.yml
+++ b/.github/workflows/callable-prebuild-samples-staging.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Setup samples staging

--- a/.github/workflows/callable-publish-preid.yml
+++ b/.github/workflows/callable-publish-preid.yml
@@ -31,7 +31,7 @@ jobs:
           echo "$PREID is allowed for preid release"
 
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
           token: ${{ secrets.GH_TOKEN_AMPLIFY_WRITE }}

--- a/.github/workflows/callable-publish-release.yml
+++ b/.github/workflows/callable-publish-release.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
           token: ${{ secrets.GH_TOKEN_AMPLIFY_WRITE }}

--- a/.github/workflows/callable-ts-version-unit-test.yml
+++ b/.github/workflows/callable-ts-version-unit-test.yml
@@ -12,13 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
-      - name: Setup Node.js 20
-        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.9 https://github.com/actions/setup-node/commit/1e60f620b9541d16bece96c5465dc8ee9832be0b
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20
+          node-version: 24
       - name: Enable Corepack for Yarn 4
         run: corepack enable
       - name: Install specific typescript version

--- a/.github/workflows/callable-unit-tests.yml
+++ b/.github/workflows/callable-unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Setup node and build the repository

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Setup node and build the repository

--- a/.github/workflows/prepare-revert-pr.yml
+++ b/.github/workflows/prepare-revert-pr.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-main-release.yml
+++ b/.github/workflows/push-main-release.yml
@@ -36,13 +36,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Setup node and build the repository
         uses: ./amplify-data/.github/actions/node-and-build
       - name: Configure AWS test execution credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # version 4.0.2
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
           role-to-assume: ${{ secrets.SANDBOX_E2E_RUNNER_ROLE_ARN }}
           aws-region: us-west-2

--- a/.github/workflows/push-preid-release.yml
+++ b/.github/workflows/push-preid-release.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@24cb9080177205b6e8c946b17badbe402adc938f # v3.4.0 https://github.com/actions/checkout/commit/24cb9080177205b6e8c946b17badbe402adc938f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           path: amplify-data
       - name: Setup node and build the repository


### PR DESCRIPTION
## Summary

Upgrade Node.js from 20 to 24 across all GitHub Actions workflows and composite actions, ahead of the [Node 20 deprecation on GitHub Actions runners](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) (deadline: June 2, 2026).

## Changes

### Node version
- `node-version: 20` → `node-version: 24` in all workflow and action files

### GitHub Actions updated (SHA-pinned)

| Action | Old Version | New Version |
|--------|-------------|-------------|
| `actions/checkout` | v3.4.0 / v4.1.1 | v6.0.2 |
| `actions/setup-node` | v4.0.9 | v6.3.0 |
| `actions/cache` | v4.2.0 | v5.0.3 |
| `actions/upload-artifact` | v4.5.0 | v7.0.0 |
| `actions/dependency-review-action` | (v4 pinned) | v4.9.0 (already up to date) |
| `aws-actions/configure-aws-credentials` | v4.0.2 | v6.1.0 |

### Files modified (22 files)
- 4 composite actions under `.github/actions/`
- 18 workflow files under `.github/workflows/`

## Testing
- All 22 modified YAML files pass syntax validation
- Full build succeeds on Node 24.14.0
- All core library unit tests pass (59 suites, 553 tests, 118 snapshots)
- Lint passes across all packages
