### PR TITLE
fix: allow partial input on composite-key beginsWith

### DIFF
--- a/.changeset/composite-key-beginswith-partial.md
+++ b/.changeset/composite-key-beginswith-partial.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/data-schema': patch
+---
+
+fix: allow partial input on composite-sort-key `beginsWith` so leading-field prefix queries work for 3+ field composite sort keys

--- a/packages/data-schema/src/util/Filters.ts
+++ b/packages/data-schema/src/util/Filters.ts
@@ -142,5 +142,11 @@ export type ModelPrimaryCompositeKeyInput<
   ge?: SkIr;
   gt?: SkIr;
   between?: [SkIr, SkIr];
-  beginsWith?: SkIr;
+  // `beginsWith` accepts a partial because the underlying AppSync VTL builds
+  // the `begins_with` prefix by skipping null fields. Requiring all fields
+  // (as the other operators do) forces callers to pass empty strings for
+  // trailing fields, which the VTL then appends as `#` delimiters — yielding
+  // a malformed prefix on 3+ field composite sort keys. Allowing partial
+  // input lets callers express "all rows under this leading prefix".
+  beginsWith?: Partial<SkIr>;
 };

--- a/packages/integration-tests/__tests__/defined-behavior/2-expected-use/primary-and-secondary-indexes.ts
+++ b/packages/integration-tests/__tests__/defined-behavior/2-expected-use/primary-and-secondary-indexes.ts
@@ -590,6 +590,30 @@ describe('Secondary Indexes', () => {
       type _AssertLength = Expect<Equal<BetweenTuple['length'], 2>>;
     });
 
+    test('ModelPrimaryCompositeKeyInput beginsWith accepts partial inputs', () => {
+      type SkShape = { sk1: string; sk2: number };
+      type CompositeInput = ModelPrimaryCompositeKeyInput<SkShape>;
+
+      // Full input — every sort-key field provided
+      const fullBeginsWith: CompositeInput = {
+        beginsWith: { sk1: 'a', sk2: 1 },
+      };
+      expect(fullBeginsWith.beginsWith).toEqual({ sk1: 'a', sk2: 1 });
+
+      // Partial input — only the leading field. The AppSync VTL skips null
+      // fields when building the `begins_with` prefix, so this is the only
+      // way to express a prefix scan on the leading subset of a composite
+      // sort key. Other operators (eq/lt/le/gt/ge/between) still require the
+      // full key shape because they need exact-match or range bounds.
+      const partialBeginsWith: CompositeInput = {
+        beginsWith: { sk1: 'a' },
+      };
+      expect(partialBeginsWith.beginsWith).toEqual({ sk1: 'a' });
+
+      type BeginsWithType = NonNullable<CompositeInput['beginsWith']>;
+      type _AssertPartial = Expect<Equal<BeginsWithType, Partial<SkShape>>>;
+    });
+
     test('the generated modelIntrospection schema contains the expected index fields and key metadata', async () => {
       expect.assertions(4);
 


### PR DESCRIPTION
## Problem

`ModelPrimaryCompositeKeyInput.beginsWith` currently requires *every* sort-key field as a non-optional string (it uses `SkIr` directly, the same shape as `eq`/`between`/etc.). For 3+ field composite sort keys, this makes it impossible to express a prefix scan on the leading subset of fields.

**Concrete example.** Given a model with sort key `a#b#c#d`, suppose a caller wants every row whose key begins with `<aValue>#`. The natural attempt is:

```ts
client.models.X.list({
  pk,
  aBCD: { beginsWith: { a: aValue, b: '', c: '', d: '' } },
});
```

The AppSync VTL builds the begins_with prefix by walking each provided field and appending it with a `#` delimiter. Empty strings are not null, so the VTL appends them as zero-length values with delimiters — yielding the malformed prefix `<aValue>###`, which matches no real rows.

There is no input the caller can construct today that produces the desired `<aValue>#` prefix:
- Omitting trailing fields: TS rejects (they're required strings)
- `null`/`undefined`: same TS rejection

The 2-field case (`{ a, b: '' }` → `<a>#`) happens to work because one trailing delimiter is itself a valid prefix boundary. The 3+ field case has no equivalent escape hatch.

**Issue number, if available:** [aws-amplify/amplify-data#719](https://github.com/aws-amplify/amplify-data/issues/719)

## Changes

One-line type change:

```diff
-  beginsWith?: SkIr;
+  beginsWith?: Partial<SkIr>;
```

The underlying AppSync VTL (in `amplify-category-api`'s `applyCompositeKeyConditionExpression`, `dynamodbUtils.ts:276–292`) already handles null fields correctly — it uses `!$util.isNull(...)` per field and skips nulls when building the prefix. The bug is purely in the TypeScript surface; `Partial<SkIr>` matches what the resolver already accepts.

Other operators (`eq`, `lt`, `le`, `gt`, `ge`, `between`) intentionally still require the full key shape because they need exact-match or range bounds.

## Validation

- Added `ModelPrimaryCompositeKeyInput beginsWith accepts partial inputs` test in `packages/integration-tests/__tests__/defined-behavior/2-expected-use/primary-and-secondary-indexes.ts` covering both runtime and type-level assertions for partial input.
- All existing tests pass (`yarn test` in `packages/data-schema`: 551/551; `packages/integration-tests` primary-and-secondary-indexes: 17 passed, 6 skipped, 0 failures).
- Manually validated against a real AppSync deployment with a 4-field composite sort key (`slotGameId#elementId#sourceImageId#extraId`) — passing `{ slotGameId, elementId: '' }` correctly returned the rows for the matching `slotGameId`. Partition pre-fetch latency on the production publish flow dropped from ~14s to ~1.9s by switching from a partition-key + filter workaround to a proper key-condition query enabled by this change.

## Checklist

- [x] Added test
- [x] Created changeset
- [x] Conventional commit message
- [x] No public API breaking changes (the change is strictly more permissive — any input that was valid before is still valid)
