### PR TITLE
fix(deps): force ws resolution to ^8.20.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "uuid": "^11.1.1",
     "js-cookie": "^3.0.7",
     "webpack-dev-server": "^5.2.4",
-    "brace-expansion": "^5.0.6"
+    "brace-expansion": "^5.0.6",
+    "ws": "^8.20.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -24185,21 +24185,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.18.0":
-  version: 8.20.0
-  resolution: "ws@npm:8.20.0"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ">=5.0.2"
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10c0/956ac5f11738c914089b65878b9223692ace77337ba55379ae68e1ecbeae9b47a0c6eb9403688f609999a58c80d83d99865fe0029b229d308b08c1ef93d4ea14
-  languageName: node
-  linkType: hard
-
 "ws@npm:^8.20.1":
   version: 8.20.1
   resolution: "ws@npm:8.20.1"


### PR DESCRIPTION
Forces all transitive ws dependencies to resolve to >=8.20.1, fixing Dependabot alert #189 (GHSA vulnerable range >= 8.0.0, < 8.20.1). The direct deps were bumped in #734 but webpack-dev-server still pulled ws@8.20.0 transitively.