### PR TITLE
chore(ci): add least-privilege permissions to workflows

### DIFF
--- a/.github/workflows/callable-e2e-test.yml
+++ b/.github/workflows/callable-e2e-test.yml
@@ -40,6 +40,9 @@ on:
 env:
   AMPLIFY_DIR: /home/runner/work/amplify-data/amplify-data/amplify-data
 
+permissions:
+  contents: read
+
 jobs:
   e2e-test:
     name: E2E ${{ inputs.test_name }}

--- a/.github/workflows/callable-e2e-tests.yml
+++ b/.github/workflows/callable-e2e-tests.yml
@@ -2,6 +2,9 @@ name: E2E Tests
 
 on: workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   e2e-prep:
     name: Get E2E test config

--- a/.github/workflows/callable-local-e2e-test.yml
+++ b/.github/workflows/callable-local-e2e-test.yml
@@ -14,6 +14,9 @@ on:
         required: true
         type: number
 
+permissions:
+  contents: read
+
 jobs:
   e2e-test:
     name: E2E ${{ inputs.test_name }}

--- a/.github/workflows/callable-local-e2e-tests.yml
+++ b/.github/workflows/callable-local-e2e-tests.yml
@@ -2,6 +2,9 @@ name: Local E2E Tests
 
 on: workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   unit_test:
     name: Local E2E Tests

--- a/.github/workflows/callable-prebuild-amplify-data.yml
+++ b/.github/workflows/callable-prebuild-amplify-data.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   prebuild:
     name: Prebuild on ${{ inputs.runs_on }}

--- a/.github/workflows/callable-prebuild-samples-staging.yml
+++ b/.github/workflows/callable-prebuild-samples-staging.yml
@@ -5,6 +5,10 @@ on:
     secrets:
       AMPLIFY_JS_SAMPLES_STAGING_READ:
         required: true
+
+permissions:
+  contents: read
+
 jobs:
   pre-staging:
     name: Prebuild Staging

--- a/.github/workflows/callable-publish-preid.yml
+++ b/.github/workflows/callable-publish-preid.yml
@@ -11,6 +11,9 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Publish to Amplify Package

--- a/.github/workflows/callable-publish-release.yml
+++ b/.github/workflows/callable-publish-release.yml
@@ -2,6 +2,9 @@ name: Release and update repository
 
 on: workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Publish to Amplify Package

--- a/.github/workflows/callable-release-verification.yml
+++ b/.github/workflows/callable-release-verification.yml
@@ -2,6 +2,9 @@ name: Release Verification Tests
 
 on: workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   prebuild-ubuntu:
     uses: ./.github/workflows/callable-prebuild-amplify-data.yml

--- a/.github/workflows/callable-ts-version-unit-test.yml
+++ b/.github/workflows/callable-ts-version-unit-test.yml
@@ -6,6 +6,10 @@ on:
       tsVersion:
         required: true
         type: string
+
+permissions:
+  contents: read
+
 jobs:
   unit_test:
     name: Lint & Unit Tests

--- a/.github/workflows/callable-unit-tests.yml
+++ b/.github/workflows/callable-unit-tests.yml
@@ -2,6 +2,9 @@ name: Unit Tests
 
 on: workflow_call
 
+permissions:
+  contents: read
+
 jobs:
   unit_test:
     name: Lint & Unit Tests

--- a/.github/workflows/on-schedule-e2e-canary.yml
+++ b/.github/workflows/on-schedule-e2e-canary.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: '0 19 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   e2e-canary:
     secrets: inherit

--- a/.github/workflows/on-schedule-ts-canary.yml
+++ b/.github/workflows/on-schedule-ts-canary.yml
@@ -7,6 +7,9 @@ on:
     - cron: '0 18 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   rc-canary:
     secrets: inherit

--- a/.github/workflows/push-e2e-test.yml
+++ b/.github/workflows/push-e2e-test.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - replace-with-your-branch
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
     secrets: inherit

--- a/.github/workflows/push-main-release.yml
+++ b/.github/workflows/push-main-release.yml
@@ -15,6 +15,12 @@ on:
       # accidentally publishing changes.
       - main
 
+# Restrict the default GITHUB_TOKEN to least privilege.
+# The release job publishes via a dedicated PAT (GH_TOKEN_AMPLIFY_WRITE) / NPM_TOKEN,
+# and the sandbox_test job sets its own id-token: write for AWS OIDC below.
+permissions:
+  contents: read
+
 jobs:
   prebuild-ubuntu:
     uses: ./.github/workflows/callable-prebuild-amplify-data.yml

--- a/.github/workflows/push-preid-release.yml
+++ b/.github/workflows/push-preid-release.yml
@@ -10,6 +10,12 @@ on:
     branches:
       - feat/**/main
 
+# Restrict the default GITHUB_TOKEN to least privilege.
+# Publishing steps authenticate via a dedicated PAT (GH_TOKEN_AMPLIFY_WRITE) / NPM_TOKEN,
+# so the default token only needs read access to repository contents.
+permissions:
+  contents: read
+
 jobs:
   prebuild:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds explicit least-privilege `permissions:` blocks to the GitHub Actions workflows that previously relied on the default `GITHUB_TOKEN` scope. This resolves the 31 open CodeQL `actions/missing-workflow-permissions` code-scanning alerts (medium severity).

All flagged workflows now default to:

```yaml
permissions:
  contents: read
```

This hardens the token rather than silencing the scanner 

## Why `contents: read` is sufficient

- Publishing/release steps (`callable-publish-preid`, `callable-publish-release`) authenticate via a dedicated PAT (`GH_TOKEN_AMPLIFY_WRITE`) and `NPM_TOKEN`, not the default `GITHUB_TOKEN`, so the default token only needs read.
- The sandbox E2E job in `push-main-release.yml` retains its own job-level `id-token: write` for AWS OIDC.

## Workflows updated (16)

- push-preid-release.yml
- push-main-release.yml
- push-e2e-test.yml
- on-schedule-ts-canary.yml
- on-schedule-e2e-canary.yml
- callable-release-verification.yml
- callable-unit-tests.yml
- callable-ts-version-unit-test.yml
- callable-prebuild-amplify-data.yml
- callable-prebuild-samples-staging.yml
- callable-e2e-tests.yml
- callable-e2e-test.yml
- callable-local-e2e-tests.yml
- callable-local-e2e-test.yml
- callable-publish-preid.yml
- callable-publish-release.yml

## Testing

- All 16 YAML files validated with a parser.
- CI-only changes (no package source touched), so no changeset is required (`changeset status` passes).
