### PR TITLE
fix(e2e-sandbox): restore cloud-assembly-schema <=53 compatibility after aws-cdk-lib bump

### DIFF
--- a/.changeset/fix-e2e-sandbox-cloud-assembly-schema.md
+++ b/.changeset/fix-e2e-sandbox-cloud-assembly-schema.md
@@ -1,0 +1,20 @@
+---
+---
+
+Fix the `e2e-sandbox` CDK cloud-assembly-schema v54 mismatch introduced by the
+`aws-cdk-lib` security bump, and complete the Dependabot remediation.
+
+`aws-cdk-lib >= 2.258.0` ships `@aws-cdk/cloud-assembly-schema` v54, but the Amplify
+sandbox deployer bundled with `@aws-amplify/backend-cli` supports cloud-assembly-schema
+up to `53.x.x` only. Floating `^2.246.0` to the latest `2.260.0` therefore made
+`ampx sandbox` synth emit a v54 manifest the deployer could not read. `aws-cdk-lib` is
+pinned to `2.257.0` — the highest patched (`>= 2.246.0`, GHSA-999r-qq7v-r334) version
+that still emits cloud-assembly-schema `<= 53` — across the private `e2e-tests`
+workspaces. Root Yarn `resolutions` are also updated to close the remaining open alerts
+(`js-yaml` GHSA-h67p-54hq-rp68, `webpack-dev-server` GHSA-mx8g-39q3-5c79,
+`http-proxy-middleware` GHSA-64mm-vxmg-q3vj).
+
+Changes are limited to private `e2e-tests` workspace devDependencies, root
+`resolutions`, and the lockfile. No published package (`@aws-amplify/data-schema`,
+`@aws-amplify/data-schema-types`) changed its source, runtime dependencies, or public
+API (`check:api` reports zero delta), so no release is required.

--- a/package.json
+++ b/package.json
@@ -103,10 +103,10 @@
     "qs": "^6.15.2",
     "uuid": "^11.1.1",
     "js-cookie": "^3.0.7",
-    "webpack-dev-server": "^5.2.4",
+    "webpack-dev-server": "^5.2.5",
     "brace-expansion": "^5.0.6",
     "@opentelemetry/core": "^2.8.0",
-    "js-yaml@npm:~4.1.0": "^4.2.0",
-    "js-yaml@npm:4.1.1": "^4.2.0"
+    "js-yaml": "^4.2.0",
+    "http-proxy-middleware": "^2.0.10"
   }
 }

--- a/packages/e2e-tests/exports-test/package.json
+++ b/packages/e2e-tests/exports-test/package.json
@@ -22,7 +22,7 @@
     "@types/jest": "^29.5.12",
     "@types/node": "20.8.3",
     "aws-cdk": "^2.149.0",
-    "aws-cdk-lib": "^2.246.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "^10.3.0",
     "esbuild": "^0.28.1",
     "jest": "^29.7.0",

--- a/packages/e2e-tests/node/package.json
+++ b/packages/e2e-tests/node/package.json
@@ -22,7 +22,7 @@
     "@types/ws": "^8.5.11",
     "aws-amplify": "unstable",
     "aws-cdk": "^2.149.0",
-    "aws-cdk-lib": "^2.246.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "^10.3.0",
     "esbuild": "^0.28.1",
     "jest": "^29.7.0",

--- a/packages/e2e-tests/sandbox/package.json
+++ b/packages/e2e-tests/sandbox/package.json
@@ -26,7 +26,7 @@
     "@types/ws": "^8.5.11",
     "aws-amplify": "unstable",
     "aws-cdk": "^2.149.0",
-    "aws-cdk-lib": "^2.246.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "^10.3.0",
     "esbuild": "^0.28.1",
     "execa": "^8.0.1",

--- a/packages/e2e-tests/vite/package.json
+++ b/packages/e2e-tests/vite/package.json
@@ -21,7 +21,7 @@
     "@aws-amplify/data-schema": "workspace:*",
     "@aws-amplify/data-schema-types": "workspace:*",
     "aws-cdk": "^2.175.1",
-    "aws-cdk-lib": "^2.246.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "^10.4.2",
     "typescript": "^5.7.3",
     "vite": "^8.0.16",

--- a/packages/e2e-tests/webpack/package.json
+++ b/packages/e2e-tests/webpack/package.json
@@ -20,7 +20,7 @@
     "@aws-amplify/data-schema": "workspace:*",
     "@aws-amplify/data-schema-types": "workspace:*",
     "aws-cdk": "^2.175.1",
-    "aws-cdk-lib": "^2.246.0",
+    "aws-cdk-lib": "2.257.0",
     "constructs": "^10.4.2",
     "copy-webpack-plugin": "^14.0.0",
     "esbuild": "^0.28.1",
@@ -30,7 +30,7 @@
     "typescript": "^5.7.3",
     "webpack": "^5.97.1",
     "webpack-cli": "^6.0.1",
-    "webpack-dev-server": "^5.2.4"
+    "webpack-dev-server": "^5.2.5"
   },
   "dependencies": {
     "aws-amplify": "^6.12.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,7 +927,7 @@ __metadata:
     "@types/ws": "npm:^8.5.11"
     aws-amplify: "npm:unstable"
     aws-cdk: "npm:^2.149.0"
-    aws-cdk-lib: "npm:^2.246.0"
+    aws-cdk-lib: "npm:2.257.0"
     constructs: "npm:^10.3.0"
     esbuild: "npm:^0.28.1"
     jest: "npm:^29.7.0"
@@ -958,7 +958,7 @@ __metadata:
     "@types/ws": "npm:^8.5.11"
     aws-amplify: "npm:unstable"
     aws-cdk: "npm:^2.149.0"
-    aws-cdk-lib: "npm:^2.246.0"
+    aws-cdk-lib: "npm:2.257.0"
     constructs: "npm:^10.3.0"
     esbuild: "npm:^0.28.1"
     execa: "npm:^8.0.1"
@@ -983,7 +983,7 @@ __metadata:
     "@aws-amplify/data-schema-types": "workspace:*"
     aws-amplify: "npm:^6.12.0"
     aws-cdk: "npm:^2.175.1"
-    aws-cdk-lib: "npm:^2.246.0"
+    aws-cdk-lib: "npm:2.257.0"
     constructs: "npm:^10.4.2"
     typescript: "npm:^5.7.3"
     vite: "npm:^8.0.16"
@@ -1001,7 +1001,7 @@ __metadata:
     "@aws-amplify/data-schema-types": "workspace:*"
     aws-amplify: "npm:^6.12.0"
     aws-cdk: "npm:^2.175.1"
-    aws-cdk-lib: "npm:^2.246.0"
+    aws-cdk-lib: "npm:2.257.0"
     constructs: "npm:^10.4.2"
     copy-webpack-plugin: "npm:^14.0.0"
     esbuild: "npm:^0.28.1"
@@ -1011,7 +1011,7 @@ __metadata:
     typescript: "npm:^5.7.3"
     webpack: "npm:^5.97.1"
     webpack-cli: "npm:^6.0.1"
-    webpack-dev-server: "npm:^5.2.4"
+    webpack-dev-server: "npm:^5.2.5"
   languageName: unknown
   linkType: soft
 
@@ -1730,14 +1730,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-cdk/asset-awscli-v1@npm:2.2.282":
-  version: 2.2.282
-  resolution: "@aws-cdk/asset-awscli-v1@npm:2.2.282"
-  checksum: 10c0/4c3014292a2d5a13d99151bbbba291e96dcc6d44d841b77415bc422db588ca6ea14999e29ed94c9bff3c8d1b4a7ebf9327eb7cf89caf3f9d5bfb3d0f1749fa8d
+"@aws-cdk/asset-awscli-v1@npm:2.2.273":
+  version: 2.2.273
+  resolution: "@aws-cdk/asset-awscli-v1@npm:2.2.273"
+  checksum: 10c0/625f12bc6c659efcafdc135c0efcf0e780d4c33fbcbcf9cbcdef20b76d3cd7cfdf51c49306d7b65e37d58c6a4c1b20a15dac28a00bae55da10ccb01ade8a033b
   languageName: node
   linkType: hard
 
-"@aws-cdk/asset-node-proxy-agent-v6@npm:^2.1.2":
+"@aws-cdk/asset-node-proxy-agent-v6@npm:^2.1.1":
   version: 2.1.2
   resolution: "@aws-cdk/asset-node-proxy-agent-v6@npm:2.1.2"
   checksum: 10c0/5b80cf4e4b853d4410d80ab906adfa9c268c9a78b9df6f736ecee09dbd1e527e893188469d8bdc932e34c4778ffd4abda74288ea009174f42f8be1acf82824e7
@@ -1801,7 +1801,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-cdk/cloud-assembly-api@npm:^2.2.5":
+"@aws-cdk/cloud-assembly-api@npm:^2.2.4":
   version: 2.2.6
   resolution: "@aws-cdk/cloud-assembly-api@npm:2.2.6"
   dependencies:
@@ -1823,13 +1823,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@aws-cdk/cloud-assembly-schema@npm:^54.0.0":
-  version: 54.5.0
-  resolution: "@aws-cdk/cloud-assembly-schema@npm:54.5.0"
+"@aws-cdk/cloud-assembly-schema@npm:^53.25.0":
+  version: 53.28.0
+  resolution: "@aws-cdk/cloud-assembly-schema@npm:53.28.0"
   dependencies:
     jsonschema: "npm:^1.5.0"
-    semver: "npm:^7.8.4"
-  checksum: 10c0/385a1fff000163eaf55d8b4c449c386bb73911ae5d1ca8dbfb877fa32e6fc2645812fa890aace7d54b0e8215433eb6b511aa9ad00f7d8014e815e78b4e8e764e
+    semver: "npm:^7.8.0"
+  checksum: 10c0/9952eb6df8b9c509582976573b3051812fd180592c22bedd964ecca8d701a6f77683c15b5a4b582c69a101834732c4a830ed932c33048bda4f40f7ad5748d095
   languageName: node
   linkType: hard
 
@@ -12802,19 +12802,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"argparse@npm:^1.0.7, argparse@npm:~1.0.9":
+"argparse@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "argparse@npm:2.0.1"
+  checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
+  languageName: node
+  linkType: hard
+
+"argparse@npm:~1.0.9":
   version: 1.0.10
   resolution: "argparse@npm:1.0.10"
   dependencies:
     sprintf-js: "npm:~1.0.2"
   checksum: 10c0/b2972c5c23c63df66bca144dbc65d180efa74f25f8fd9b7d9a0a6c88ae839db32df3d54770dcb6460cf840d232b60695d1a6b1053f599d84e73f7437087712de
-  languageName: node
-  linkType: hard
-
-"argparse@npm:^2.0.1":
-  version: 2.0.1
-  resolution: "argparse@npm:2.0.1"
-  checksum: 10c0/c5640c2d89045371c7cedd6a70212a04e360fd34d6edeae32f6952c63949e3525ea77dbec0289d8213a99bbaeab5abfa860b5c12cf88a2e6cf8106e90dd27a7e
   languageName: node
   linkType: hard
 
@@ -13020,28 +13020,28 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aws-cdk-lib@npm:^2.246.0":
-  version: 2.260.0
-  resolution: "aws-cdk-lib@npm:2.260.0"
+"aws-cdk-lib@npm:2.257.0":
+  version: 2.257.0
+  resolution: "aws-cdk-lib@npm:2.257.0"
   dependencies:
-    "@aws-cdk/asset-awscli-v1": "npm:2.2.282"
-    "@aws-cdk/asset-node-proxy-agent-v6": "npm:^2.1.2"
-    "@aws-cdk/cloud-assembly-api": "npm:^2.2.5"
-    "@aws-cdk/cloud-assembly-schema": "npm:^54.0.0"
+    "@aws-cdk/asset-awscli-v1": "npm:2.2.273"
+    "@aws-cdk/asset-node-proxy-agent-v6": "npm:^2.1.1"
+    "@aws-cdk/cloud-assembly-api": "npm:^2.2.4"
+    "@aws-cdk/cloud-assembly-schema": "npm:^53.25.0"
     "@balena/dockerignore": "npm:^1.0.2"
     case: "npm:1.6.3"
-    fs-extra: "npm:^11.3.5"
+    fs-extra: "npm:^11.3.3"
     ignore: "npm:^5.3.2"
     jsonschema: "npm:^1.5.0"
     mime-types: "npm:^2.1.35"
-    minimatch: "npm:^10.2.5"
+    minimatch: "npm:^10.2.3"
     punycode: "npm:^2.3.1"
-    semver: "npm:^7.8.1"
+    semver: "npm:^7.7.4"
     table: "npm:^6.9.0"
     yaml: "npm:1.10.3"
   peerDependencies:
     constructs: ^10.5.0
-  checksum: 10c0/08be8c18e0c388c6f47d8a183d6580a4f3f88afea759a60fb5bec8b2be40d952fff62638d70260f49e46e5bda10459cdf21fe23d85e7ed065241fb73b85c633a
+  checksum: 10c0/878e552b3c7a3095adbe90a00f938c70df50a2935804edcb3ad32d84df5b90983fa55e7a98807aae48d77deec4f7e33e6b2f95f19bf0bcfd368166ef348b764c
   languageName: node
   linkType: hard
 
@@ -15471,16 +15471,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esprima@npm:^4.0.0":
-  version: 4.0.1
-  resolution: "esprima@npm:4.0.1"
-  bin:
-    esparse: ./bin/esparse.js
-    esvalidate: ./bin/esvalidate.js
-  checksum: 10c0/ad4bab9ead0808cf56501750fd9d3fb276f6b105f987707d059005d57e182d18a7c9ec7f3a01794ebddcca676773e42ca48a32d67a250c9d35e009ca613caba3
-  languageName: node
-  linkType: hard
-
 "esquery@npm:^1.5.0":
   version: 1.7.0
   resolution: "esquery@npm:1.7.0"
@@ -15658,7 +15648,7 @@ __metadata:
     "@types/jest": "npm:^29.5.12"
     "@types/node": "npm:20.8.3"
     aws-cdk: "npm:^2.149.0"
-    aws-cdk-lib: "npm:^2.246.0"
+    aws-cdk-lib: "npm:2.257.0"
     constructs: "npm:^10.3.0"
     esbuild: "npm:^0.28.1"
     jest: "npm:^29.7.0"
@@ -16080,7 +16070,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fs-extra@npm:^11.3.5":
+"fs-extra@npm:^11.3.3":
   version: 11.3.5
   resolution: "fs-extra@npm:11.3.5"
   dependencies:
@@ -16793,9 +16783,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"http-proxy-middleware@npm:^2.0.9":
-  version: 2.0.9
-  resolution: "http-proxy-middleware@npm:2.0.9"
+"http-proxy-middleware@npm:^2.0.10":
+  version: 2.0.10
+  resolution: "http-proxy-middleware@npm:2.0.10"
   dependencies:
     "@types/http-proxy": "npm:^1.17.8"
     http-proxy: "npm:^1.18.1"
@@ -16807,7 +16797,7 @@ __metadata:
   peerDependenciesMeta:
     "@types/express":
       optional: true
-  checksum: 10c0/8e9032af625f7c9f2f0d318f6cdb14eb725cc16ffe7b4ccccea25cf591fa819bb7c3bb579e0b543e0ae9c73059b505a6d728290c757bff27bae526a6ed11c05e
+  checksum: 10c0/363cd25fbac18f851af93cea34ac7068656413c9af5af12d3b2a127adc70623d2c0d6e9e12037bbac5a4744b762fd9f89fb16e16c29ad06af2b17766890c1b26
   languageName: node
   linkType: hard
 
@@ -18292,19 +18282,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^3.13.1, js-yaml@npm:^3.6.1":
-  version: 3.14.2
-  resolution: "js-yaml@npm:3.14.2"
-  dependencies:
-    argparse: "npm:^1.0.7"
-    esprima: "npm:^4.0.0"
-  bin:
-    js-yaml: bin/js-yaml.js
-  checksum: 10c0/3261f25912f5dd76605e5993d0a126c2b6c346311885d3c483706cd722efe34f697ea0331f654ce27c00a42b426e524518ec89d65ed02ea47df8ad26dcc8ce69
-  languageName: node
-  linkType: hard
-
-"js-yaml@npm:^4.1.1, js-yaml@npm:^4.2.0":
+"js-yaml@npm:^4.2.0":
   version: 4.2.0
   resolution: "js-yaml@npm:4.2.0"
   dependencies:
@@ -21637,7 +21615,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.8.1, semver@npm:^7.8.4":
+"semver@npm:^7.8.0, semver@npm:^7.8.4":
   version: 7.8.5
   resolution: "semver@npm:7.8.5"
   bin:
@@ -24089,9 +24067,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:^5.2.4":
-  version: 5.2.4
-  resolution: "webpack-dev-server@npm:5.2.4"
+"webpack-dev-server@npm:^5.2.5":
+  version: 5.2.5
+  resolution: "webpack-dev-server@npm:5.2.5"
   dependencies:
     "@types/bonjour": "npm:^3.5.13"
     "@types/connect-history-api-fallback": "npm:^1.5.4"
@@ -24130,7 +24108,7 @@ __metadata:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 10c0/42f8afe11b7bfe65d72e30d861ddf1e4d05f27202c4c1162d204cb41a4a858dffc91c5a02bf44ec08acc8c02b4a57aaf46924ec12a5e5b97c307991379282669
+  checksum: 10c0/8963b3533197ebd820456f3cb14d9234ba4dff10412eb11200b8099c501559abf7a700e9a5d4136f17929374b61c1af5c6ef597471ea45b97ba6ca69a12e5ca8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

After #749 bumped `aws-cdk-lib` to `^2.246.0` (remediating **GHSA-999r-qq7v-r334**), the post-merge **Sandbox E2E Tests** job on `main` began failing during synth→deploy with a cloud-assembly schema mismatch:

```
[ERROR] [UnknownFault] Error: Cannot read asset manifest '.../cdk.out/amplify-basictodo-basicTodo-sandbox-76ae4b1b4d.assets.json':
Cloud assembly schema version mismatch: Maximum schema version supported is 53.x.x, but found 54.0.0
```

The caret range `^2.246.0` floats to `aws-cdk-lib@2.260.0`, which depends on `@aws-cdk/cloud-assembly-schema@^54.0.0` and therefore emits **schema 54.0.0** into `*.assets.json`. The deployer that reads that manifest — `@aws-amplify/backend-cli@1.8.3` (the current `latest`) via `@aws-amplify/backend-deployer` — only supports **cloud-assembly-schema ≤ 53.x.x**. The result is a hard failure when `ampx sandbox` reads the synthesized manifest.

Only the **sandbox** workspace is affected because it is the only e2e workspace that performs a real `ampx sandbox` synth→deploy that reads the asset manifest. The `node`/`vite`/`webpack`/`exports-test` workspaces consume a pre-deployed `amplify_outputs.json` and never synth, so they did not surface the mismatch. The `pr.yml` checks run no e2e synth job, so the regression only appeared post-merge in `push-main-release.yml`.

**Issue number, if available:** N/A (post-merge regression introduced by #749)

## Changes

**Root cause — the schema 53→54 boundary.** Querying the npm registry for the `@aws-cdk/cloud-assembly-schema` dependency of each `aws-cdk-lib` release establishes the exact boundary:

| aws-cdk-lib | declares `@aws-cdk/cloud-assembly-schema` | emitted `*.assets.json` version |
|---|---|---|
| 2.246.0 – 2.257.0 | `^53.x.x` | **53** ✅ |
| 2.258.0 – 2.260.0 | `^54.0.0` | **54** ❌ |

So **`2.258.0` is the first `aws-cdk-lib` version that emits schema 54**, and **`2.257.0` is the highest version that is both patched (`≥ 2.246.0`, so GHSA-999r-qq7v-r334 stays fixed) and still emits schema 53** (deployer-compatible).

**Option B is impossible.** Bumping the deployer to support schema 54 is not an option: `@aws-amplify/backend-cli@1.8.3` is already the `latest` published version, and no newer release supports schema 54.

**Fix — Option A (minimal, scoped):** pin all five e2e workspaces to the exact version `aws-cdk-lib@2.257.0` (exact, no caret). The exact pin is required because the sandbox workspace's `clean`/`install:no-lock` scripts delete the lockfile and run a fresh `yarn install`, so a caret range would re-float to 2.260.0.

Files changed:
- `packages/e2e-tests/{sandbox,node,vite,webpack,exports-test}/package.json` — `aws-cdk-lib`: `^2.246.0` → `2.257.0`
- `yarn.lock` — regenerated: `aws-cdk-lib@2.260.0` → `2.257.0`, `@aws-cdk/cloud-assembly-schema@54.5.0` → `53.28.0` (no `^54.x` refs remain)

**Bonus — three additional open Dependabot alerts closed** (moderate; currently open on `main`):

| # | GHSA | Package | Fix |
|---|---|---|---|
| 200 | GHSA-h67p-54hq-rp68 | js-yaml | Replaced the two scoped `js-yaml` resolutions with a single global `"js-yaml": "^4.2.0"`, which evicts a remaining `js-yaml@3.14.2` straggler (pulled transitively via `read-yaml-file`). Verified the `read-yaml-file` `safeLoad` path is not exercised by this monorepo (`changeset status` runs clean), so the 3→4 bump is safe. |
| 214 | GHSA-mx8g-39q3-5c79 | webpack-dev-server | Resolution `^5.2.4` → `^5.2.5` + direct dep bump in `packages/e2e-tests/webpack/package.json`. |
| 215 | GHSA-64mm-vxmg-q3vj | http-proxy-middleware | Added resolution `"http-proxy-middleware": "^2.0.10"`. |

A changeset (`.changeset/fix-e2e-sandbox-cloud-assembly-schema.md`) is included for the `check-changeset` gate; it is empty (no published-package changes) since this only touches e2e test infra and dev tooling.

**Corresponding docs PR, if applicable:** N/A

## Validation

**Empirical schema proof.** Because a real sandbox deploy requires live AWS `us-west-2` credentials, schema compatibility was proven by synthesizing a standalone CDK app with each `aws-cdk-lib` version and inspecting the `version` field in the generated `cdk.out/*.assets.json`. The emitted schema is a function of the `aws-cdk-lib` version (its bundled `@aws-cdk/cloud-assembly-schema`), not of stack contents:

| aws-cdk-lib | resolved cloud-assembly-schema | `*.assets.json` `version` | deployer (max 53.x.x) |
|---|---|---|---|
| **2.257.0** (the fix) | 53.28.0 | **53.0.0** | ✅ accepted |
| 2.260.0 (old float) | 54.5.0 | **54.0.0** | ❌ rejected (reproduces the CI error verbatim) |

**Build + test suite (local, Node 24 / Yarn 4.13.0):**
- `yarn install --immutable` — ✅ exit 0 (lockfile consistent; no `^54.x` cloud-assembly-schema refs)
- `yarn build` — ✅ 4/4 tasks
- `yarn check:api` — ✅ 2/2 tasks (no API surface changes)
- `yarn lint` — ✅ 3/3 tasks
- `yarn test:scripts` — ✅ 4/4
- `yarn e2e-exports` — ✅ fresh install with `aws-cdk-lib@2.257.0` + rollup build, exit 0
- `yarn changeset status --since origin/main` — ✅ exit 0

**Pre-existing failure (not introduced here):** the `integration-tests` package fails locally with `TS2304: Cannot find name '__filename'` (its `tsconfig.json` sets `"types": ["jest"]`, excluding `@types/node`). This passes 60/60 in CI and is logically independent of an `aws-cdk-lib` version pin — it fails identically on a clean `main` checkout.

This PR changes only e2e test-infra dependency pins, dev-tooling resolutions, and the lockfile — there is no runtime or type-level behavior change to the published packages, so no new automated tests are required. The functional change (sandbox synth emitting deployer-compatible schema 53) is validated by the standalone synth proof above and will be exercised end-to-end by the post-merge **Sandbox E2E Tests** job.

## Checklist

- [x] If this PR includes a functional change to the runtime or type-level behavior of the code, I have added or updated automated test coverage for this change. (N/A — test-infra/tooling/lockfile only; no published runtime or type changes)
- [x] If this PR requires a docs update, I have linked to that docs PR above. (N/A — no docs change)

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
