### PR TITLE
ci: fix TS canary failures

### DIFF
--- a/.github/workflows/callable-ts-version-unit-test.yml
+++ b/.github/workflows/callable-ts-version-unit-test.yml
@@ -36,4 +36,9 @@ jobs:
           force: true
       - name: Run tests
         working-directory: ./amplify-data
+        # Newer TypeScript compilers use more memory type-checking this repo's
+        # generic-heavy types via ts-jest, exceeding V8's default (~4GB) heap.
+        # Raise the limit so the canary reports real regressions, not OOMs.
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
         run: yarn lint && yarn test


### PR DESCRIPTION
## Problem

The scheduled Typescript Canary workflow has been failing on all three jobs (`rc`, `next`, `latest`) due to two issues introduced by newer TypeScript releases:

1. **`rc` install fails.** `typescript@rc` now resolves to TypeScript 7.0, whose package layout no longer includes `lib/_tsc.js`. Yarn's built-in TypeScript compat patch hard-codes that path and aborts the install with `ENOENT ... _tsc.js`. The patch only matters under the PnP linker; this repo uses `nodeLinker: node-modules`, so it provides no value here.
2. **`latest`/`next` OOM.** Suites pass, then a `ts-jest` worker exceeds V8's default (~4 GB) heap and crashes (`JavaScript heap out of memory`). Newer TS compilers use more memory type-checking this repo's generic-heavy types.

## Changes

Both scoped to `.github/workflows/callable-ts-version-unit-test.yml` (used only by the canary). No source, dependencies, or published artifacts are affected.

- Waiting on https://github.com/yarnpkg/berry/pull/7190 to land - fixing the `rc` install against the TS 7.0 layout.
- Set `NODE_OPTIONS=--max-old-space-size=8192` on the test step, fixing the `latest`/`next` OOM.

## Validation

- YAML validated locally.
- Test-infra-only change with no functional/runtime impact, so no new automated tests are required.
- https://github.com/aws-amplify/amplify-data/actions/runs/28626118135/job/84892889938

## Checklist

- [x] If this PR includes a functional change to the runtime or type-level behavior of the code, I have added or updated automated test coverage for this change. _(N/A — CI/test-infra only.)_
- [x] If this PR requires a docs update, I have linked to that docs PR above. _(N/A)_

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
