### PR TITLE
feat: add minimizeRdsVpcEndpoints to SQL DataSourceConfiguration

### DIFF
--- a/.changeset/minimize-rds-vpc-endpoints.md
+++ b/.changeset/minimize-rds-vpc-endpoints.md
@@ -1,0 +1,5 @@
+---
+'@aws-amplify/data-schema-types': minor
+---
+
+Add optional `minimizeRdsVpcEndpoints` to the SQL data source configuration, allowing customers to opt into provisioning only the SSM VPC endpoint for the RDS-in-VPC SQL Lambda (reduces 5 endpoints to 1). Defaults to false (unchanged behavior); SQL data sources only.

--- a/packages/data-schema-types/docs/data-schema-types.datasourceconfiguration.md
+++ b/packages/data-schema-types/docs/data-schema-types.datasourceconfiguration.md
@@ -15,6 +15,7 @@ export type DataSourceConfiguration<DE extends DatasourceEngine = DatasourceEngi
     vpcConfig?: VpcConfig;
     identifier?: string;
     sslCert?: BackendSecret;
+    minimizeRdsVpcEndpoints?: boolean;
 };
 ```
 **References:** [DatasourceEngine](./data-schema-types.datasourceengine.md)

--- a/packages/data-schema-types/src/builder/types.ts
+++ b/packages/data-schema-types/src/builder/types.ts
@@ -92,6 +92,12 @@ export type DataSourceConfiguration<
       vpcConfig?: VpcConfig;
       identifier?: string;
       sslCert?: BackendSecret;
+      /**
+       * When true, provisions only the SSM interface VPC endpoint for the SQL Lambda,
+       * instead of the full set. Defaults to false (all endpoints) for backward compatibility.
+       * Only has an effect when vpcConfig is set.
+       */
+      minimizeRdsVpcEndpoints?: boolean;
     };
 
 export type SchemaConfiguration<


### PR DESCRIPTION
## Summary

Adds an optional `minimizeRdsVpcEndpoints?: boolean` to the SQL branch of `DataSourceConfiguration` in `packages/data-schema-types/src/builder/types.ts`.

This lets Gen2 `defineData` customers opt into a reduced set of RDS-in-VPC interface endpoints for the SQL Lambda: when set to `true`, only the `ssm` interface VPC endpoint is provisioned (5 → 1) instead of the full set. It only has an effect when `vpcConfig` is set.

- **Default `false`** — unchanged 5-endpoint behavior, fully backward compatible.
- **SQL-only** — the DynamoDB branch of `DataSourceConfiguration` is unaffected.

## Coordinated change (3 repos)

This is part of a 3-repo coordinated change:

1. **amplify-category-api** (released) — `SQLLambdaModelDataSourceStrategy.minimizeRdsVpcEndpoints`. See aws-amplify/amplify-category-api#3449 and issue aws-amplify/amplify-category-api#3409.
2. **amplify-data** (this PR) — surface the option on the SQL `DataSourceConfiguration` type.
3. **amplify-backend** `backend-data` (pending) — `convert_schema` mapping to pass the flag through.

## Notes

- `data-schema` (the runtime builder) needs no change — the value is a structural passthrough.
