### PR TITLE
fix(security): bump websocket-driver 0.7.4 -> 0.7.5 (dependabot #217)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -24169,13 +24169,13 @@ __metadata:
   linkType: hard
 
 "websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "websocket-driver@npm:0.7.4"
+  version: 0.7.5
+  resolution: "websocket-driver@npm:0.7.5"
   dependencies:
     http-parser-js: "npm:>=0.5.1"
     safe-buffer: "npm:>=5.1.0"
     websocket-extensions: "npm:>=0.1.1"
-  checksum: 10c0/5f09547912b27bdc57bac17b7b6527d8993aa4ac8a2d10588bb74aebaf785fdcf64fea034aae0c359b7adff2044dd66f3d03866e4685571f81b13e548f9021f1
+  checksum: 10c0/843a3c9f529ce07f2721829f70f62986247525ab22625e857b69da13dc90967bacfe57b85e196801b565cd797e309ddd5b06fa8435732e34e8a8ab6201d7abed
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Security fix

Resolves **Dependabot alert #217** (critical): https://github.com/aws-amplify/amplify-data/security/dependabot/217

**Finding:** `websocket-driver` <0.7.5 — Message corruption via abuse of protocol length headers (CVE-2026-54466 / GHSA-xv26-6w52-cph6). Transitive runtime dependency locked at 0.7.4 in `yarn.lock` (via `sockjs@0.3.24 -> websocket-driver ^0.7.4` and `faye-websocket@0.11.4 -> websocket-driver >=0.5.1`).

## Fix

Lockfile-only change: ran `yarn up -R websocket-driver` (Yarn 4.13.0) to re-resolve the merged `websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4` entry from 0.7.4 to **0.7.5** (first patched version). 0.7.5 satisfies both existing semver ranges, so no `package.json` or `resolutions` change is required. No code changes.

Verified `yarn.lock` now resolves `websocket-driver@npm:0.7.5` and no <0.7.5 entry remains.

## CI verification

- `yarn install` — OK
- `yarn build` (turbo, 4 tasks) — passed
- `yarn lint` (3 tasks) — passed
- `yarn test` — 540 tests passed. 9 integration-tests suites fail with `TS2304: Cannot find name '__filename'` — confirmed **pre-existing on main** (reproduced with the pristine main lockfile), unrelated to this change.