### PR TITLE
fix(security): bump immutable 5.1.5 -> 5.1.9 (dependabot #226)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16976,9 +16976,9 @@ __metadata:
   linkType: hard
 
 "immutable@npm:^5.1.5":
-  version: 5.1.5
-  resolution: "immutable@npm:5.1.5"
-  checksum: 10c0/8017ece1578e3c5939ba3305176aee059def1b8a90c7fa2a347ef583ebbd38cbe77ce1bbd786a5fab57e2da00bbcb0493b92e4332cdc4e1fe5cfb09a4688df31
+  version: 5.1.9
+  resolution: "immutable@npm:5.1.9"
+  checksum: 10c0/ae7032b60b81b682f3e7e4df13e1ec9a401a603eb81b15bb3e37331ed6666e318c71994c6936e1462eb443d32d04769396562a7e2669da22457c8ba279c03ad2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Security fix

Resolves **dependabot alert #226** (severity: **high**): https://github.com/aws-amplify/amplify-data/security/dependabot/226

- **GHSA-xvcm-6775-5m9r / CVE-2026-59880** — Hash-collision algorithmic complexity denial of service in `Immutable.Map`/`Immutable.Set`
- Affected: `immutable` (transitive, runtime scope), vulnerable ranges `<4.3.9` and `>=5.0.0-beta.1 <5.1.8`
- Repo resolved `immutable@5.1.5` via the `immutable@npm:^5.1.5` lockfile entry

## Change

Yarn.lock-only change: ran `yarn up -R immutable` with the repo's own yarn (4.13.0), bumping the `immutable@npm:^5.1.5` resolution from **5.1.5 → 5.1.9** (patched). No `package.json` or source changes — semver-compatible patch bump of a transitive dependency.

## Verification

- `yarn why immutable` shows `immutable@npm:5.1.9` for all 4 consumers (`@ardatan/relay-compiler` variants); no vulnerable resolution remains
- `yarn install --immutable` exits 0 on the committed lockfile (a consistent lockfile — this is what makes dependabot's PR #759 red with YN0028)
- `yarn build` (turbo) passes 4/4 tasks; unit test suites pass (e.g. `@aws-amplify/data-schema` 37/37). The 9 failing `integration-tests` suites fail identically on unmodified `origin/main` (pre-existing local env issue, unrelated).

## Note

Dependabot PR #759 attempts the same bump but has an inconsistent committed lockfile (CI fails on `yarn install --immutable`, YN0028). Once this merges, #759 can be closed as superseded.