### PR TITLE
fix: don't require nullable list arguments on custom operations

### DIFF
--- a/.changeset/fix-nullable-list-custom-operation-argument.md
+++ b/.changeset/fix-nullable-list-custom-operation-argument.md
@@ -1,0 +1,9 @@
+---
+'@aws-amplify/data-schema': patch
+---
+
+Fix the client-side `requires arguments` error thrown for nullable list arguments on custom operations ([#767](https://github.com/aws-amplify/amplify-data/issues/767)).
+
+An argument declared as `a.ref('Color').required().array()` is emitted as `[Color!]` — a nullable list of non-null elements — so omitting it is valid, but the client rejected the call before sending a request. The model introspection schema encodes _element_ nullability in `isRequired` and _list_ nullability in `isArrayNullable`, and the pre-flight check in `operationVariables()` read `isRequired` alone. It now derives argument nullability the same way `outerArguments()` derives the rendered variable type, so the two can no longer disagree.
+
+Conversely, omitting a non-null list argument (`a.string().array().required()`, i.e. `[String]!`) now fails that pre-flight check instead of sending a request that declares a non-null variable with no value. Such a request was already rejected by AppSync, and the argument is required at the type level, so only untyped callers are affected. For them the failure surfaces differently: a query or mutation now rejects instead of resolving to `{ data: null, errors }`, and a subscription now throws synchronously instead of returning an observable that errors. That matches the pre-existing behavior for a non-null scalar argument.

--- a/packages/data-schema/__tests__/internals/operations/custom.test.ts
+++ b/packages/data-schema/__tests__/internals/operations/custom.test.ts
@@ -1,5 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { of } from 'rxjs';
+
 import { customOpFactory } from '../../../src/runtime/internals/operations/custom';
 import {
   AmplifyClass,
@@ -7,6 +9,7 @@ import {
   BaseBrowserClient,
   ClientInternalsGetter,
   CustomOperation,
+  CustomOperationArgument,
   GraphQLResult,
   GraphQLAuthMode,
   ModelIntrospectionSchema,
@@ -124,5 +127,291 @@ describe('customOpFactory', () => {
       }),
       undefined,
     );
+  });
+
+  describe('argument nullability', () => {
+    const operationWithArgs = (
+      args: NonNullable<CustomOperation['arguments']>,
+    ): CustomOperation => ({
+      ...mockOperation,
+      arguments: args,
+    });
+
+    /**
+     * Returns the un-awaited call so tests can distinguish a rejection from a
+     * synchronous throw. `_op` is wrapped in `selfAwareAsync`, so the query and
+     * mutation paths must always reject.
+     */
+    const call =
+      (operation: CustomOperation, args: Record<string, unknown>) => () =>
+        customOpFactory(
+          mockClient,
+          mockModelIntrospection,
+          'query',
+          operation,
+          false,
+          mockGetInternals,
+        )(args);
+
+    const invoke = async (
+      operation: CustomOperation,
+      args: Record<string, unknown>,
+    ) => call(operation, args)();
+
+    /**
+     * `[Color!]` — a nullable list of non-null elements. The model introspection
+     * schema encodes element nullability in `isRequired`, so `isRequired: true`
+     * here does *not* mean the argument itself is required.
+     */
+    const nullableListOfRequiredElements: CustomOperationArgument = {
+      name: 'colors',
+      type: { enum: 'Color' },
+      isArray: true,
+      isRequired: true,
+      isArrayNullable: true,
+    };
+
+    it.each<[string, CustomOperationArgument, string]>([
+      [
+        'a nullable list of non-null elements ([Color!])',
+        nullableListOfRequiredElements,
+        'query($colors: [Color!]) {',
+      ],
+      [
+        'a nullable list of nullable elements ([Color])',
+        {
+          name: 'colors',
+          type: { enum: 'Color' },
+          isArray: true,
+          isRequired: false,
+          isArrayNullable: true,
+        },
+        'query($colors: [Color]) {',
+      ],
+      [
+        'a nullable scalar (String)',
+        {
+          name: 'colors',
+          type: 'String',
+          isArray: false,
+          isRequired: false,
+        },
+        'query($colors: String) {',
+      ],
+    ])(
+      'does not throw when %s is omitted',
+      async (_name, argDef, expectedQuery) => {
+        await invoke(operationWithArgs({ colors: argDef }), {});
+
+        expect(mockClient.graphql).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: expect.stringContaining(expectedQuery),
+            variables: {},
+          }),
+          undefined,
+        );
+      },
+    );
+
+    it('does not throw when only the required arguments of a mixed signature are provided', async () => {
+      await invoke(
+        operationWithArgs({
+          label: {
+            name: 'label',
+            type: 'String',
+            isArray: false,
+            isRequired: false,
+          },
+          colors: nullableListOfRequiredElements,
+        }),
+        { label: 'foo' },
+      );
+
+      expect(mockClient.graphql).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: { label: 'foo' },
+        }),
+        undefined,
+      );
+    });
+
+    it('passes a nullable list argument through as a variable when provided', async () => {
+      await invoke(
+        operationWithArgs({ colors: nullableListOfRequiredElements }),
+        {
+          colors: ['RED', 'BLUE'],
+        },
+      );
+
+      expect(mockClient.graphql).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: { colors: ['RED', 'BLUE'] },
+        }),
+        undefined,
+      );
+    });
+
+    it.each<[string, CustomOperationArgument]>([
+      [
+        'a non-null list of non-null elements ([Color!]!)',
+        {
+          name: 'colors',
+          type: { enum: 'Color' },
+          isArray: true,
+          isRequired: true,
+          isArrayNullable: false,
+        },
+      ],
+      [
+        'a non-null list of nullable elements ([Color]!)',
+        {
+          name: 'colors',
+          type: { enum: 'Color' },
+          isArray: true,
+          isRequired: false,
+          isArrayNullable: false,
+        },
+      ],
+      [
+        // `isArrayNullable` is optional in the introspection schema; when absent
+        // `outerArguments()` renders a non-null list, so the argument is required.
+        'a list with an unspecified list nullability',
+        {
+          name: 'colors',
+          type: { enum: 'Color' },
+          isArray: true,
+          isRequired: true,
+        },
+      ],
+      [
+        'a non-null scalar (String!)',
+        {
+          name: 'colors',
+          type: 'String',
+          isArray: false,
+          isRequired: true,
+        },
+      ],
+    ])('rejects when %s is omitted', async (_name, argDef) => {
+      // `_op` is wrapped in `selfAwareAsync`, so this must reject rather than
+      // throw synchronously -- a synchronous throw fails on this line.
+      const pending = call(operationWithArgs({ colors: argDef }), {})();
+
+      await expect(pending).rejects.toThrow(
+        "testQuery requires arguments 'colors'",
+      );
+
+      expect(mockClient.graphql).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The rendered variable type and the pre-flight check must agree, so pin the
+     * rendering for every list shape as well as the check above.
+     */
+    it.each<[string, boolean, boolean, string]>([
+      ['[Color!]', true, true, 'query($colors: [Color!]) {'],
+      ['[Color]', false, true, 'query($colors: [Color]) {'],
+      ['[Color!]!', true, false, 'query($colors: [Color!]!) {'],
+      ['[Color]!', false, false, 'query($colors: [Color]!) {'],
+    ])(
+      'renders %s as the variable type',
+      async (_name, isRequired, isArrayNullable, expected) => {
+        const argDef: CustomOperationArgument = {
+          name: 'colors',
+          type: { enum: 'Color' },
+          isArray: true,
+          isRequired,
+          isArrayNullable,
+        };
+
+        await invoke(operationWithArgs({ colors: argDef }), {
+          colors: ['RED'],
+        });
+
+        expect(mockClient.graphql).toHaveBeenCalledWith(
+          expect.objectContaining({
+            query: expect.stringContaining(expected),
+          }),
+          undefined,
+        );
+      },
+    );
+
+    it('renders a list with an unspecified list nullability as non-null', async () => {
+      // The pre-flight check treats this shape as required specifically because
+      // this is what gets rendered; keep the two pinned together.
+      const argDef: CustomOperationArgument = {
+        name: 'colors',
+        type: { enum: 'Color' },
+        isArray: true,
+        isRequired: true,
+      };
+
+      await invoke(operationWithArgs({ colors: argDef }), {
+        colors: ['RED'],
+      });
+
+      expect(mockClient.graphql).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: expect.stringContaining('query($colors: [Color!]!) {'),
+        }),
+        undefined,
+      );
+    });
+
+    describe('on the subscription path', () => {
+      // `_opSubscription` shares `operationVariables()` but is not wrapped in
+      // `selfAwareAsync`, so it throws synchronously rather than rejecting.
+      const subscribe = (operation: CustomOperation) => {
+        const subClient: BaseBrowserClient = {
+          ...mockClient,
+          graphql: jest
+            .fn()
+            .mockReturnValue(
+              of({ data: { testQuery: 'result' } }),
+            ) as jest.MockedFunction<BaseBrowserClient['graphql']>,
+        };
+
+        const customOp = customOpFactory(
+          subClient,
+          mockModelIntrospection,
+          'subscription',
+          operation,
+          false,
+          mockGetInternals,
+        );
+
+        return { subClient, run: () => customOp({}) };
+      };
+
+      it('does not throw when a nullable list argument is omitted', () => {
+        const { subClient, run } = subscribe(
+          operationWithArgs({ colors: nullableListOfRequiredElements }),
+        );
+
+        expect(run).not.toThrow();
+        expect(subClient.graphql).toHaveBeenCalledWith(
+          expect.objectContaining({ variables: {} }),
+          undefined,
+        );
+      });
+
+      it('throws when a non-null list argument is omitted', () => {
+        const { subClient, run } = subscribe(
+          operationWithArgs({
+            colors: {
+              name: 'colors',
+              type: { enum: 'Color' },
+              isArray: true,
+              isRequired: true,
+              isArrayNullable: false,
+            },
+          }),
+        );
+
+        expect(run).toThrow("testQuery requires arguments 'colors'");
+        expect(subClient.graphql).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/packages/data-schema/src/runtime/internals/operations/custom.ts
+++ b/packages/data-schema/src/runtime/internals/operations/custom.ts
@@ -212,8 +212,12 @@ function isInputType(type: InputFieldType): type is InputType {
 }
 
 /**
+ * For a list argument this is the *element* type, so `isRequired` — which is
+ * element-level for lists — is the correct source for the `!`. The list's own
+ * nullability is applied by the caller. See {@link isArgumentRequired}.
+ *
  * @param argDef A single argument definition from a custom operation
- * @returns A string naming the base type including the `!` if the arg is required.
+ * @returns A string naming the base type including the `!` if that type is non-null.
  */
 function argumentBaseTypeString({ type, isRequired }: CustomOperationArgument) {
   const requiredFlag = isRequired ? '!' : '';
@@ -224,6 +228,35 @@ function argumentBaseTypeString({ type, isRequired }: CustomOperationArgument) {
     return `${type.input}${requiredFlag}`;
   }
   return `${type}${requiredFlag}`;
+}
+
+/**
+ * Determines whether a value must be provided for a custom operation argument,
+ * i.e. whether the argument itself is non-null in the GraphQL schema.
+ *
+ * For list arguments, the model introspection schema encodes *element* nullability
+ * in `isRequired` and *list* nullability in `isArrayNullable`. For example, an
+ * argument declared as `a.ref('Color').required().array()` is emitted as `[Color!]`
+ * and introspected as `{ isArray: true, isRequired: true, isArrayNullable: true }`
+ * — a nullable list of non-null elements, so the argument itself is optional. Only
+ * the outermost nullability determines whether the caller has to supply a value.
+ *
+ * `isArrayNullable` is optional in the introspection schema. The generator we
+ * build against always emits it for list arguments (`getTypeInfo()` sets
+ * `isListNullable` on every list branch), but when it is absent we treat the list
+ * as non-null to stay consistent with the `[T]!` that `outerArguments()` renders
+ * for the same input — a request declaring a non-null variable with no value
+ * would be rejected by the server anyway.
+ *
+ * @param argDef A single argument definition from a custom operation
+ * @returns Boolean: `true` if the argument itself is non-null
+ */
+function isArgumentRequired({
+  isArray,
+  isRequired,
+  isArrayNullable,
+}: CustomOperationArgument): boolean {
+  return isArray ? !isArrayNullable : isRequired;
 }
 
 /**
@@ -253,7 +286,7 @@ function outerArguments(operation: CustomOperation): string {
     .map(([k, argument]) => {
       const baseType = argumentBaseTypeString(argument);
       const finalType = argument.isArray
-        ? `[${baseType}]${argument.isArrayNullable ? '' : '!'}`
+        ? `[${baseType}]${isArgumentRequired(argument) ? '!' : ''}`
         : baseType;
 
       return `$${k}: ${finalType}`;
@@ -357,7 +390,7 @@ function operationVariables(
   for (const argDef of Object.values(operation.arguments)) {
     if (typeof args[argDef.name] !== 'undefined') {
       variables[argDef.name] = args[argDef.name];
-    } else if (argDef.isRequired) {
+    } else if (isArgumentRequired(argDef)) {
       // At this point, the variable is both required and missing: We don't need
       // to continue. The operation is expected to fail.
       throw new Error(`${operation.name} requires arguments '${argDef.name}'`);

--- a/packages/integration-tests/__tests__/defined-behavior/2-expected-use/custom-operations.ts
+++ b/packages/integration-tests/__tests__/defined-behavior/2-expected-use/custom-operations.ts
@@ -729,4 +729,151 @@ describe('custom operations', () => {
       const { data } = await client.queries.echoEnum({ status: 'BAD VALUE' });
     });
   });
+
+  describe('with list arguments', () => {
+    const schema = a.schema({
+      Color: a.enum(['RED', 'GREEN', 'BLUE']),
+      // `[Color!]` -- a nullable list of non-null elements, so omitting the
+      // argument is valid.
+      nullableList: a
+        .query()
+        .arguments({
+          colors: a.ref('Color').required().array(),
+        })
+        .returns(a.string())
+        .handler(a.handler.function('name' as any))
+        .authorization((allow) => [allow.publicApiKey()]),
+      // `[Color]!` -- a non-null list, so the argument must be provided.
+      requiredList: a
+        .query()
+        .arguments({
+          colors: a.ref('Color').array().required(),
+        })
+        .returns(a.string())
+        .handler(a.handler.function('name' as any))
+        .authorization((allow) => [allow.publicApiKey()]),
+    });
+
+    type Schema = ClientSchema<typeof schema>;
+
+    test('encode element nullability separately from list nullability in the modelIntrospection schema', async () => {
+      const { modelIntrospection } = await buildAmplifyConfig(schema);
+
+      expect(modelIntrospection.queries.nullableList.arguments).toEqual({
+        colors: {
+          name: 'colors',
+          isArray: true,
+          type: { enum: 'Color' },
+          // element-level: `Color!`
+          isRequired: true,
+          // list-level: the list itself is nullable
+          isArrayNullable: true,
+        },
+      });
+
+      expect(modelIntrospection.queries.requiredList.arguments).toEqual({
+        colors: {
+          name: 'colors',
+          isArray: true,
+          type: { enum: 'Color' },
+          isRequired: false,
+          isArrayNullable: false,
+        },
+      });
+    });
+
+    test('mark a nullable list argument optional in the ClientSchema args', async () => {
+      type ExpectedArgs = {
+        colors?: ('RED' | 'GREEN' | 'BLUE')[] | null | undefined;
+      };
+      type test = Expect<Equal<Schema['nullableList']['args'], ExpectedArgs>>;
+    });
+
+    test('mark a non-null list argument required in the ClientSchema args', async () => {
+      type ExpectedArgs = {
+        colors: ('RED' | 'GREEN' | 'BLUE' | null | undefined)[];
+      };
+      type test = Expect<Equal<Schema['requiredList']['args'], ExpectedArgs>>;
+    });
+
+    test('send the request when a nullable list argument is omitted', async () => {
+      const { spy, generateClient } = mockedGenerateClient([
+        { data: { nullableList: 'ok' } },
+      ]);
+
+      const config = await buildAmplifyConfig(schema);
+      Amplify.configure(config);
+      const client = generateClient<Schema>();
+
+      const { data } = await client.queries.nullableList({});
+
+      expect(data).toEqual('ok');
+
+      const [[options]] = optionsAndHeaders(spy);
+      expectGraphqlMatches(
+        options.query,
+        `
+        query($colors: [Color!]) {
+          nullableList(colors: $colors)
+        }
+      `,
+      );
+      expect(options.variables).toEqual({});
+    });
+
+    test('send a nullable list argument as a variable when provided', async () => {
+      const { spy, generateClient } = mockedGenerateClient([
+        { data: { nullableList: 'ok' } },
+      ]);
+
+      const config = await buildAmplifyConfig(schema);
+      Amplify.configure(config);
+      const client = generateClient<Schema>();
+
+      await client.queries.nullableList({ colors: ['RED', 'BLUE'] });
+
+      const [[options]] = optionsAndHeaders(spy);
+      expect(options.variables).toEqual({ colors: ['RED', 'BLUE'] });
+    });
+
+    test('throw before sending when a non-null list argument is omitted', async () => {
+      const { spy, generateClient } = mockedGenerateClient([
+        { data: { requiredList: 'ok' } },
+      ]);
+
+      const config = await buildAmplifyConfig(schema);
+      Amplify.configure(config);
+      const client = generateClient<Schema>();
+
+      await expect(
+        // @ts-expect-error `colors` is a required property of the args type, as
+        // pinned above -- only untyped callers can reach the runtime check.
+        client.queries.requiredList({}),
+      ).rejects.toThrow("requiredList requires arguments 'colors'");
+
+      expect(optionsAndHeaders(spy)).toEqual([]);
+    });
+
+    test('render a non-null list argument as a non-null variable', async () => {
+      const { spy, generateClient } = mockedGenerateClient([
+        { data: { requiredList: 'ok' } },
+      ]);
+
+      const config = await buildAmplifyConfig(schema);
+      Amplify.configure(config);
+      const client = generateClient<Schema>();
+
+      await client.queries.requiredList({ colors: ['RED'] });
+
+      const [[options]] = optionsAndHeaders(spy);
+      expectGraphqlMatches(
+        options.query,
+        `
+        query($colors: [Color]!) {
+          requiredList(colors: $colors)
+        }
+      `,
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Problem

`a.ref('X').required().array()` on a custom operation argument produces the GraphQL type `[X!]` — a **nullable** list of non-null elements. AppSync accepts requests that omit such an argument, but the generated data client threw before issuing a request:

```ts
const schema = a.schema({
  Color: a.enum(['RED', 'GREEN', 'BLUE']),
  myQuery: a
    .query()
    .arguments({
      label: a.string(),
      colors: a.ref('Color').required().array(), // [Color!]
    })
    .returns(a.string())
    .handler(a.handler.function(myFn))
    .authorization((allow) => [allow.authenticated()]),
});

client.queries.myQuery({ label: 'foo' });
// Error: myQuery requires arguments 'colors'
```

The model introspection schema encodes _element_ nullability in `isRequired` and _list_ nullability in `isArrayNullable`, so `[Color!]` is `{ isArray: true, isRequired: true, isArrayNullable: true }`. The pre-flight check in `operationVariables()` read `argDef.isRequired` alone and treated it as "the argument itself is required":

```ts
} else if (argDef.isRequired) {
  throw new Error(`${operation.name} requires arguments '${argDef.name}'`);
}
```

`outerArguments()` in the same file already distinguished the two correctly and rendered the variable as `$colors: [Color!]` (optional), so the pre-flight check disagreed with the document the client itself was about to send. The static `ClientSchema` types also already mark the argument optional, so this only ever blocked callers at runtime.

Latent since the initial custom operations implementation (aws-amplify/amplify-js#13029), but only reachable for `a.ref()` arguments after #552 (1.20.1) started emitting `.required()`/`.array()` on ref arguments into the SDL.

**Issue number, if available:** #767

## Changes

- Add `isArgumentRequired(argDef)` — `isArray ? !isArrayNullable : isRequired` — reading the _outermost_ nullability, which is what decides whether the caller must supply a value.
- Use it for the pre-flight check in `operationVariables()`.
- Route `outerArguments()`'s list `!` suffix through the same helper. This is a byte-for-byte no-op (inside that branch `isArray` is already truthy, so `isArgumentRequired(arg) ? '!' : ''` reduces to the previous `arg.isArrayNullable ? '' : '!'`), but it means the rendered variable type and the pre-flight check are now derived from one place and cannot drift apart again.
- Correct the `argumentBaseTypeString` doc comment, which described its `!` as the argument's rather than the element's — the exact conflation this PR fixes.

Behavior for every argument shape:

| Shape   | `isRequired` / `isArrayNullable` | Before   | After                       |
| ------- | -------------------------------- | -------- | --------------------------- |
| `[X]`   | false / true                     | no throw | no throw                    |
| `[X!]`  | true / true                      | **throw**| **no throw** ← the fix      |
| `[X]!`  | false / false                    | no throw | **throw** ← see below       |
| `[X!]!` | true / false                     | throw    | throw                       |
| `X`     | false / —                        | no throw | no throw                    |
| `X!`    | true / —                         | throw    | throw                       |

`[X]!` is the one tightening. It cannot break a working call: the client always declares `$x` and always passes it inner, so omitting the argument previously sent `query($x: [X]!)` with `variables: {}` — a non-null variable with no value, which AppSync rejects. The argument is also required at the `ClientSchema` type level, so only untyped callers can reach it. The failure mode does change for them (a query/mutation now rejects instead of resolving to `{ data: null, errors }`; a subscription throws synchronously instead of returning an erroring observable), which matches the long-standing behavior for a non-null scalar argument and is called out in the changeset.

`isArrayNullable` is optional in `bridge-types.ts`. When absent for a list argument the helper treats the list as non-null, which keeps it consistent with the `[T]!` that `outerArguments()` renders for the same input. In practice the case is unreachable: `getTypeInfo()` in `@aws-amplify/appsync-modelgen-plugin` sets `isListNullable` on every branch that sets `isList: true`, so new-client × old-`amplify_outputs.json` behaves identically to before.

No public API surface change (`yarn check:api` reports 0 differences), so this is a `patch`.

**Corresponding docs PR, if applicable:** n/a

## Validation

Unit tests — `packages/data-schema/__tests__/internals/operations/custom.test.ts`:

- Full enumeration of both sides of the check: no-throw for `[X!]`, `[X]`, `X`; reject for `[X!]!`, `[X]!`, a list with `isArrayNullable` absent, and `X!`. Each no-throw case also pins the rendered variable declaration.
- The rendered variable type for all four list shapes plus the `isArrayNullable`-absent case, so the invariant that the check and the rendering agree is pinned on both sides.
- The `_opSubscription` path, which shares `operationVariables()` but is not wrapped in `selfAwareAsync` and so throws synchronously rather than rejecting.

Integration tests — `packages/integration-tests/__tests__/defined-behavior/2-expected-use/custom-operations.ts`, new `describe('with list arguments')`. These build the config from **real** `@aws-amplify/appsync-modelgen-plugin` output via `buildAmplifyConfig`, so they pin the fix at the layer the bug actually lived in rather than against a hand-written introspection shape:

- The real introspection for `[Color!]` really is `{ isArray: true, isRequired: true, isArrayNullable: true }` and for `[Color]!` really is `{ isArray: true, isRequired: false, isArrayNullable: false }` — a canary on the metadata contract this fix depends on.
- `ClientSchema` marks the `[Color!]` argument optional and the `[Color]!` argument required.
- Calling with the nullable list argument omitted sends `query($colors: [Color!])` with `variables: {}`; omitting the non-null list argument still rejects before anything is sent.

Reverting only `packages/data-schema/src/.../custom.ts` (and rebuilding `dist/`, which `packages/integration-tests` resolves through) fails 4 unit tests and 2 integration tests, so the new coverage genuinely guards the fix rather than passing either way.

Full local run: `yarn build`, `yarn lint`, `yarn test` (data-schema 568 tests / 37 suites, integration-tests 556 passed + 9 skipped / 60 suites, 388 snapshots unchanged), `yarn check:api` (0 differences), `yarn check:type-perf`, and `yarn changeset status --since origin/main` all pass.

## Checklist

- [x] If this PR includes a functional change to the runtime or type-level behavior of the code, I have added or updated automated test coverage for this change. (see [Testing Strategy README](../TESTING-STRATEGY.md))
- [x] If this PR requires a docs update, I have linked to that docs PR above.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
