### PR TITLE
fix(security): force postcss >= 8.5.12 via scoped resolution (dependabot #236)

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "brace-expansion": "^5.0.6",
     "@opentelemetry/core": "^2.8.0",
     "js-yaml": "^4.2.0",
-    "http-proxy-middleware": "^2.0.10"
+    "http-proxy-middleware": "^2.0.10",
+    "next/postcss": "^8.5.12"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19563,15 +19563,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
-  languageName: node
-  linkType: hard
-
 "napi-postinstall@npm:^0.3.0":
   version: 0.3.4
   resolution: "napi-postinstall@npm:0.3.4"
@@ -20559,18 +20550,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.5.12":
-  version: 8.5.23
-  resolution: "postcss@npm:8.5.23"
-  dependencies:
-    nanoid: "npm:^3.3.16"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/ed714e635b330bb42666ecdd0c0b4f30224ded15b0b0052d6bc2b92832f2cf17d1c1141359453f96f0a84f8fbf4c405a74df187f559163b8f31131b2535455aa
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.15":
+"postcss@npm:^8.5.12, postcss@npm:^8.5.15":
   version: 8.5.23
   resolution: "postcss@npm:8.5.23"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -19563,12 +19563,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.6":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:^3.3.16":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
   languageName: node
   linkType: hard
 
@@ -20440,7 +20440,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.0.0, picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
+"picocolors@npm:^1.1.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -20559,14 +20559,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.31":
-  version: 8.4.31
-  resolution: "postcss@npm:8.4.31"
+"postcss@npm:^8.5.12":
+  version: 8.5.23
+  resolution: "postcss@npm:8.5.23"
   dependencies:
-    nanoid: "npm:^3.3.6"
-    picocolors: "npm:^1.0.0"
-    source-map-js: "npm:^1.0.2"
-  checksum: 10c0/748b82e6e5fc34034dcf2ae88ea3d11fd09f69b6c50ecdd3b4a875cfc7cdca435c958b211e2cb52355422ab6fccb7d8f2f2923161d7a1b281029e4a913d59acf
+    nanoid: "npm:^3.3.16"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/ed714e635b330bb42666ecdd0c0b4f30224ded15b0b0052d6bc2b92832f2cf17d1c1141359453f96f0a84f8fbf4c405a74df187f559163b8f31131b2535455aa
   languageName: node
   linkType: hard
 
@@ -22079,7 +22079,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf


### PR DESCRIPTION
## Security fix

Resolves **Dependabot alert #236** (high severity): https://github.com/aws-amplify/amplify-data/security/dependabot/236

**Finding:** postcss — Arbitrary file read and information disclosure via attacker-controlled `sourceMappingURL` in CSS comments (CVE-2026-45623, GHSA-6g55-p6wh-862q). Vulnerable range: `<= 8.5.11`; first patched: `8.5.12`. Transitive dev dependency in the root `yarn.lock`.

**Why Dependabot can't auto-fix:** the vulnerable `postcss@8.4.31` enters via `next@16.2.6`, which pins it exactly (`npm:8.4.31`), so a plain upgrade won't help.

## Fix

- Added one scoped yarn resolution in the root `package.json`: `"next/postcss": "^8.5.12"` — following the repo's existing scoped-resolution precedent (e.g. `next/sharp` from #765). No other resolutions touched.
- Regenerated `yarn.lock` via `yarn install`: the vulnerable `postcss@npm:8.4.31` entry is replaced by `postcss@npm:^8.5.12` → **8.5.23**. The already-safe vite-side `postcss@^8.5.15` entry is untouched.

## Verification

- `yarn why postcss` shows only 8.5.23 (next) and 8.5.15 (vite) — no version `<= 8.5.11` remains anywhere in `yarn.lock`.
- CI scripts pass locally: `yarn build` ✅, `yarn lint` ✅, `yarn check:api` ✅, `yarn test:scripts` ✅ (4/4); unit tests: 540 passed. (9 integration-test suites fail locally with a pre-existing environment error — `TS2304: Cannot find name '__filename'` — reproduced identically on an unmodified `origin/main` baseline; unrelated to this change.)
