### PR TITLE
fix(security): re-resolve postcss@^8.5.15 to 8.5.23 (GHSA-r28c-9q8g-f849)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -19554,12 +19554,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
-  version: 3.3.12
-  resolution: "nanoid@npm:3.3.12"
+"nanoid@npm:^3.3.16":
+  version: 3.3.16
+  resolution: "nanoid@npm:3.3.16"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
+  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
   languageName: node
   linkType: hard
 
@@ -20571,13 +20571,13 @@ __metadata:
   linkType: hard
 
 "postcss@npm:^8.5.15":
-  version: 8.5.15
-  resolution: "postcss@npm:8.5.15"
+  version: 8.5.23
+  resolution: "postcss@npm:8.5.23"
   dependencies:
-    nanoid: "npm:^3.3.12"
+    nanoid: "npm:^3.3.16"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7f2e63ae22fbe43aace1bf652bd99da4e90737c64194d49e51ddc9cd0f9e51ff2861a7d734379b494deffa03a880a5c65eec70bc29ee9ebaa7136dde3eee8f31
+  checksum: 10c0/ed714e635b330bb42666ecdd0c0b4f30224ded15b0b0052d6bc2b92832f2cf17d1c1141359453f96f0a84f8fbf4c405a74df187f559163b8f31131b2535455aa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Security Fix

**Finding:** Dependabot alert [#250](https://github.com/aws-amplify/amplify-data/security/dependabot/250) — **high** severity
**Advisory:** [GHSA-r28c-9q8g-f849](https://github.com/advisories/GHSA-r28c-9q8g-f849) — PostCSS: Path Traversal in Previous Source Map Auto-Loading (sourceMappingURL) leads to Arbitrary .map File Disclosure
**Vulnerable range:** postcss <= 8.5.17 · **First patched:** 8.5.18

## Changes

Lockfile-only change: re-resolves the `postcss@npm:^8.5.15` entry in `yarn.lock` from **8.5.15** (vulnerable) to **8.5.23** (patched). The declared range `^8.5.15` already admits 8.5.23, so no `package.json` edits or `resolutions` entries were needed. This also bumped postcss's transitive dep `nanoid` from 3.3.12 to 3.3.16.

The `postcss@npm:8.4.31` entry (pinned by `next`) is intentionally left untouched — it is covered by open PR #769 via a scoped resolution.

## Verification

- `grep -A2 '"postcss@' yarn.lock` shows only two entries: 8.4.31 (PR #769 scope) and 8.5.23 (>= 8.5.18)
- `yarn install --immutable` passes (lockfile consistent)
- `yarn build` passes (4/4 tasks)
- `yarn lint` passes (3/3 tasks)
- Unit tests: 4/5 turbo tasks pass; the single failure (integration-tests, TS2304 `__filename` in type-test suites) reproduces identically on unmodified `main` — pre-existing local-environment issue, unrelated to this change