### PR TITLE
fix(security): bump js-yaml to ^4.3.0 (dependabot alert #247)

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "webpack-dev-server": "^5.2.5",
     "brace-expansion": "^5.0.6",
     "@opentelemetry/core": "^2.8.0",
-    "js-yaml": "^4.2.0",
+    "js-yaml": "^4.3.0",
     "http-proxy-middleware": "^2.0.10"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18282,14 +18282,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.2.0":
-  version: 4.2.0
-  resolution: "js-yaml@npm:4.2.0"
+"js-yaml@npm:^4.3.0":
+  version: 4.3.0
+  resolution: "js-yaml@npm:4.3.0"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/1916456c118746603b067d74bbcbb0445d9a1d5e474ad4ae775e7b20525bed902e01d9d97dd0c81fcd8d4f596162309d0eb057f4aa38f3e9647f14075e9dea45
+  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Security fix

Resolves **Dependabot alert #247** (high severity): https://github.com/aws-amplify/amplify-data/security/dependabot/247

**js-yaml** — YAML merge-key chains can force quadratic CPU consumption (GHSA-52cp-r559-cp3m / CVE-2026-59869, CWE-400/CWE-407, CVSS 7.5). Vulnerable range `>=4.0.0 <4.3.0`, first patched version `4.3.0`.

## Changes

- Bumped direct devDependency `js-yaml` from `^4.2.0` to `^4.3.0` in the root `package.json`
- Regenerated `yarn.lock` via a normal `yarn install` so `js-yaml` resolves to `4.3.0` — no remaining lockfile entries in the vulnerable range

This supersedes dependabot PR #774, which failed CI (YN0028) because it updated only `package.json` without regenerating `yarn.lock`.

## Verification

- `yarn install --immutable` exits 0 (fixes the YN0028 failure mode of #774)
- `yarn build` (turbo, 4/4 tasks) passes
- Unit tests pass for all packages; `packages/integration-tests` has 9 pre-existing TS2304 `__filename` type errors reproduced identically at the base commit on `origin/main` (unrelated to this change)