### PR TITLE
fix(deps): bump undici to 7.29.0 and ip-address to 10.4.0 to address security advisories

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -17140,9 +17140,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.0.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+  version: 10.4.0
+  resolution: "ip-address@npm:10.4.0"
+  checksum: 10c0/d7b0bd2624fd861afbae6e49036a9b56f9506eaff7ff38592b7b4492dd5c272b53f5356dc8cc019e318acf29a96c90a3d1af1df761960267d23efa96858270fa
   languageName: node
   linkType: hard
 
@@ -23551,9 +23551,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^7.24.5":
-  version: 7.28.0
-  resolution: "undici@npm:7.28.0"
-  checksum: 10c0/fe781983a26098795e99bb1f64906cbb7d0bcaa029a26baade007b53ea67f2631d189b8f9671a31f4c8d0cb3773b7559608628ba54452fef51fec90e7c78bb0d
+  version: 7.29.0
+  resolution: "undici@npm:7.29.0"
+  checksum: 10c0/85ea96e91e7f3de24de678cbbc54230fdd641a3b0643005f2aef044af1f1a2db8fbecb88b28e6fa78bb41ffeafda4479b57075b6b6ab92beac4b7b5ab53f9b10
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

Four open Dependabot alerts on transitive dependencies in the root `yarn.lock`:

- **#256** (high) — `undici` cross-user information disclosure
- **#255** (medium) — `undici` downstream response desynchronization
- **#254** (medium) — `ip-address` CIDR suffix suppresses special-use classification
- **#253** (medium) — `ip-address` misclassification of IPv4-mapped / NAT64 IPv6 addresses

**Issue number, if available:** Dependabot alerts #253, #254, #255, #256

> The open `aws-cdk-lib` alerts (#219–#224) are intentionally **not** included here — that upgrade is not compatible and is being handled separately (see #760 / #758).

## Changes

- `undici` `7.28.0 → 7.29.0` (first patched version for #255/#256)
- `ip-address` `10.2.0 → 10.4.0` (first patched version for #253 is 10.2.1 and for #254 is 10.2.2; 10.4.0 is the current release and covers both — matching Dependabot PR #777)

Both are purely transitive and already within their existing ranges (`undici@^7.24.5`, `ip-address@^10.0.1`), so this is a lockfile-only re-resolution. Both target versions have no runtime dependencies, so nothing else in the tree shifts. Checksums were regenerated by `yarn install --mode=update-lockfile` (Yarn 4).

## Validation

- Confirmed each target is the first patched version for its advisory and satisfies the existing range.
- Verified both packages have no dependencies, so the change is limited to the two lockfile entries (version / resolution / checksum) with no cascading edits.
- `yarn install --mode=update-lockfile` completed cleanly (pre-existing peer-dependency warnings unchanged); diff is `yarn.lock`-only.

This is a dependency-only security fix in the lockfile; no source or test changes apply.

## Checklist

- [x] PR description included
- [ ] `yarn test` passes (CI)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
