### PR TITLE
fix(deps): bump undici, fast-uri, brace-expansion to patched versions (alerts #257-261)

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "uuid": "^11.1.1",
     "js-cookie": "^3.0.7",
     "webpack-dev-server": "^5.2.6",
-    "brace-expansion": "^5.0.8",
+    "brace-expansion": "^5.0.9",
     "@opentelemetry/core": "^2.8.0",
     "js-yaml": "^4.3.0",
     "http-proxy-middleware": "^2.0.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13544,12 +13544,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.8":
-  version: 5.0.8
-  resolution: "brace-expansion@npm:5.0.8"
+"brace-expansion@npm:^5.0.9":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
   languageName: node
   linkType: hard
 
@@ -15811,9 +15811,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.4
-  resolution: "fast-uri@npm:3.1.4"
-  checksum: 10c0/f90948821ceb49980f64f89b8216ba498f5957f26035be813526a55b6145d26cbd63ef5618d5205a3292b31edc9c08589749350cd72bd86c7095eb434dceb757
+  version: 3.1.5
+  resolution: "fast-uri@npm:3.1.5"
+  checksum: 10c0/2bf60eb800dd610c65e17be436425dcb21c92aff3a87d442a8bccab0b7b071e88cf1a5d7d1ea946370b937e6fc0375c405c0296c10587e57de4f78be4646d1d0
   languageName: node
   linkType: hard
 
@@ -23544,9 +23544,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.23.0":
-  version: 6.27.0
-  resolution: "undici@npm:6.27.0"
-  checksum: 10c0/f88c3dae3957dbf9d93cb481440aced317bd3c4941b5914fea5efba516d51138988cdb5c76006f0bb1337e41d56c3443351055d492e73af2428521c37ba2a76f
+  version: 6.28.0
+  resolution: "undici@npm:6.28.0"
+  checksum: 10c0/3029a70df06b38b5b2f30732932a1e92544c753cd82c8abdf0d35afad48e0ba91612e79fe3a442dbbb9434d6a9eba2b714d5ea28984c903dda2b5d5444f38354
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

Five new Dependabot alerts on transitive dependencies in the root `yarn.lock`:

- **#261** (medium) — `undici` CRLF injection via blob-like body
- **#260** (medium) — `undici` cookie attribute injection via unsanitized values
- **#259** (medium) — `undici` downstream response desynchronization
- **#258** (high) — `fast-uri` host confusion via backslash
- **#257** (high) — `brace-expansion` DoS via unbounded intermediate arrays

**Issue number, if available:** Dependabot alerts #257, #258, #259, #260, #261

> These `undici` alerts are on the `undici@^6.23.0` tree, which is separate from the `undici@^7.24.5` tree already fixed in #779.

## Changes

- `undici` (`^6.23.0`) `6.27.0 → 6.28.0` (#259/#260/#261)
- `fast-uri` `3.1.4 → 3.1.5` (#258)
- `brace-expansion` `5.0.8 → 5.0.9` (#257) — also bumps the `resolutions` pin (`^5.0.8 → ^5.0.9`) so the enforced version and lockfile agree

All within existing ranges; `undici`/`fast-uri` have no dependencies and `brace-expansion` keeps `balanced-match ^4.0.2`, so nothing else in the tree shifts. Checksums regenerated with Yarn 4.

> Consolidates the three Dependabot PRs #778 (undici), #781 (brace-expansion), #782 (fast-uri). Notably, **#781 fails CI** (`prebuild`) because it updated only the `resolutions` pin in `package.json` without regenerating `yarn.lock`, so the immutable install rejects it with *"The lockfile would have been modified by this install, which is explicitly forbidden."* This PR fixes that by updating both the pin and the lockfile together.

## Validation

- `yarn install --immutable` — **passes (exit 0, no YN0028)**, confirming the lockfile is consistent — the exact check #781 fails.
- Confirmed each target is the first patched version for its advisory and satisfies the existing range.
- Diff is limited to the three lockfile blocks (version / resolution / checksum) plus the one `resolutions` pin line for `brace-expansion`.

This is a dependency-only security fix; no source or test changes apply.

## Checklist

- [x] PR description included
- [ ] `yarn test` passes (CI)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
