### PR TITLE
fix(deps): bump js-yaml and nanoid to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "webpack-dev-server": "^5.2.6",
     "brace-expansion": "^5.0.9",
     "@opentelemetry/core": "^2.8.0",
-    "js-yaml": "^4.3.0",
+    "js-yaml": "^4.3.1",
     "http-proxy-middleware": "^2.0.10",
     "next/sharp": "^0.35.0",
     "next/postcss": "^8.5.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18309,14 +18309,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"js-yaml@npm:^4.3.0":
-  version: 4.3.0
-  resolution: "js-yaml@npm:4.3.0"
+"js-yaml@npm:^4.3.1":
+  version: 4.3.1
+  resolution: "js-yaml@npm:4.3.1"
   dependencies:
     argparse: "npm:^2.0.1"
   bin:
     js-yaml: bin/js-yaml.js
-  checksum: 10c0/058b30473d6915ca5b4feb11e2f7d4d97242f98d00a798ed48dd90b46b7c640398afe9128c5db22c5300f8c6528fe2a174b9a93f351a70ebc28c6203938d8bff
+  checksum: 10c0/13c500ca322e0c3f8c81686e6ecda96d2ea37b45247a420c17c7db36932d6965cc27391abc2d1a104501600e7f0d947a5f8b7be6db619c4fefa87901b3512807
   languageName: node
   linkType: hard
 
@@ -19582,11 +19582,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.16":
-  version: 3.3.16
-  resolution: "nanoid@npm:3.3.16"
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/bbf2dcffe22d2b62d16de2711752070b539c0f644c7916f823ad6521986b2078cbe524f2d6240f58c46e9141ea0c7b87a029e100c0f7f175228cacaf30e41bba
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Resolves Dependabot alerts #262 (js-yaml) and #264 (nanoid, GHSA-2v37-7h3g-55p8).

### js-yaml — scoped root resolution
Bumped the existing scoped resolution `js-yaml: ^4.3.0 -> ^4.3.1`, the minimal patched
version on the 4.x line. Scoped so no other major version line is forced to a breaking major.

### nanoid — lockfile-only bump (no resolution)
`nanoid` was resolving to `3.3.16` transitively via `postcss`, which already requests
`^3.3.16` — a range that permits the patched `3.3.18`. So no `resolutions` entry is needed
or appropriate here: the fix is purely a lockfile re-resolution done with
`corepack yarn up -R nanoid`, bumping `3.3.16 -> 3.3.18` with **zero** `package.json` change.
Adding a resolution would be redundant pinning that hides future upstream patches.

## Verification
- `yarn install --immutable` (CI's command) — exit 0
- `yarn build` — exit 0 (4/4 tasks successful)
- Diff limited to `package.json` (1 line, js-yaml) + `yarn.lock` (js-yaml + nanoid entries only), no unrelated churn
- Lockfile now has a single `js-yaml@npm:^4.3.1 -> 4.3.1` and `nanoid@npm:^3.3.16 -> 3.3.18`
